### PR TITLE
Fix issue where we may have to bundle update

### DIFF
--- a/lib/manageiq/release/release_tag.rb
+++ b/lib/manageiq/release/release_tag.rb
@@ -26,11 +26,14 @@ module ManageIQ
 
       private
 
+      def system!(*args)
+        exit($CHILD_STATUS.exitstatus) unless system(*args)
+      end
+
       def rake_release
         Bundler.with_clean_env do
-          unless system({"RELEASE_VERSION" => tag}, "bundle && bundle exec rake release", :chdir => repo.path)
-            exit($CHILD_STATUS.exitstatus)
-          end
+          system!("bundle check || bundle update", :chdir => repo.path)
+          system!({"RELEASE_VERSION" => tag}, "bundle exec rake release", :chdir => repo.path)
         end
       end
 


### PR DESCRIPTION
@simaishi Please review.

This occurred when I switched to darga branch, but of course my Gemfile.lock was from the last euwe release.  `bundle` fails, and so needs to call `bundle update`.