### PR TITLE
Added rake release for manageiq-content

### DIFF
--- a/config/repos.yml
+++ b/config/repos.yml
@@ -4,6 +4,7 @@ master:
   manageiq-appliance:
   manageiq-appliance-build:
   manageiq-content:
+    has_rake_release: true
   manageiq-gems-pending:
   manageiq-pods:
   manageiq-providers-amazon:


### PR DESCRIPTION
rake release was added to manageiq-content in
https://github.com/ManageIQ/manageiq-content/pull/78