### PR TITLE
Show Travis status for a specific branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ gem "activesupport",        :require => false
 gem "more_core_extensions", :require => false
 gem "minigit",              :require => false
 gem "octokit", ">=4.7.0",   :require => false
+gem "travis",               :require => false
 gem "trollop",              :require => false

--- a/bin/show_travis_status.rb
+++ b/bin/show_travis_status.rb
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path("../lib", __dir__)
+
+require 'bundler/setup'
+require 'manageiq/release'
+require 'more_core_extensions/core_ext/array/tableize'
+require 'travis'
+require 'trollop'
+
+opts = Trollop.options do
+  opt :branch, "The branch to check status for", :type => :string, :required => true
+end
+
+branch = opts[:branch]
+
+all_repos = ManageIQ::Release::Repos[branch]
+travis_repos = all_repos.collect do |github_repo|
+  repo = Travis::Repository.find("ManageIQ/#{github_repo.name}")
+  next unless repo.branches && repo.branches.include?(branch)
+  last_build = repo.last_on_branch(branch)
+  { "Repo" => repo.name, "Status" => last_build.state, "Date" => last_build.finished_at }
+end.compact
+
+travis_repos.sort_by! { |v| [ v["Status"], v["Date"] ] }
+puts travis_repos.tableize(:columns => ["Repo", "Status", "Date"])


### PR DESCRIPTION
The result is sorted by status, then date of the last build

```
$ bin/show_travis_status.rb -b fine
 Repo                      | Status | Date
---------------------------+--------+-------------------------
 manageiq                  | failed | 2017-11-08 15:19:45 UTC
 manageiq-providers-lenovo | passed | 2017-04-11 17:54:03 UTC
 manageiq-appliance-build  | passed | 2017-08-24 18:27:41 UTC
 manageiq-providers-vmware | passed | 2017-10-24 17:38:09 UTC
 manageiq-providers-azure  | passed | 2017-10-26 14:39:54 UTC
 manageiq-providers-amazon | passed | 2017-11-02 14:53:17 UTC
 manageiq-gems-pending     | passed | 2017-11-02 17:34:27 UTC
 manageiq-ui-service       | passed | 2017-11-02 17:43:30 UTC
 manageiq-content          | passed | 2017-11-02 18:16:05 UTC
 manageiq_docs             | passed | 2017-11-06 11:29:53 UTC
 manageiq-ui-classic       | passed | 2017-11-06 16:01:49 UTC
```