### PR TITLE
Pull latest before tagging

### DIFF
--- a/lib/manageiq/release/release_tag.rb
+++ b/lib/manageiq/release/release_tag.rb
@@ -13,6 +13,7 @@ module ManageIQ
       def run
         repo.fetch
         repo.checkout(branch)
+        repo.git.pull
         repo.options.has_rake_release ? rake_release : tagged_release
       end
 


### PR DESCRIPTION
Without `pull`, it tries to tag what's currently on the machine locally.