### PR TITLE
Add pinned label as a common label

### DIFF
--- a/config/labels.yml
+++ b/config/labels.yml
@@ -12,6 +12,7 @@ common: &common
   internationalization: "d4c5f9"
   notabug: "eeeeee"
   performance: "e99695"
+  pinned: "eeeeee"
   question: "cc317c"
   refactoring: "fbca04"
   stale: "eeeeee"


### PR DESCRIPTION
stale was already a common label, and pinned should be paired with it.
Now that the bot is watching all repos for stale issues, this missing
label became apparent.

@chessbyte @simaishi Please review.