### PR TITLE
[list_backport_pr] Add opt to open links in browser

### DIFF
--- a/bin/list_backport_pr.rb
+++ b/bin/list_backport_pr.rb
@@ -10,6 +10,7 @@ require 'trollop'
 opts = Trollop.options do
   opt :blocker, "List 'blocker' PRs only",          :type => :boolean, :default => false
   opt :branch,  "The target branch to backport to", :type => :string,  :required => true
+  opt :open,    "Open all links in a browser",      :type => :boolean, :default => false
 end
 
 branch = opts[:branch]
@@ -23,11 +24,18 @@ pr_list = []
 prs.each do |pr|
   repo = pr.repository_url.split("/").last
   label = EXTRA_LABELS & pr.labels.collect(&:name)
-  pr_list << { "Repo" => repo, "PR" => pr.number, "Label" => label.empty? ? "" : label.join(","), "Date" => pr.closed_at }
+  pr_list << {
+               "Repo"  => repo,
+               "PR"    => pr.number,
+               "Label" => label.empty? ? "" : label.join(","),
+               "Date"  => pr.closed_at,
+               "Link"  => pr.html_url
+             }
 end
 
 unless pr_list.empty?
   sorted_list = pr_list.sort_by { |v| [ v["Repo"], v["Date"] ] }
   table = sorted_list.tableize(:columns => ["Repo", "PR", "Label"])
   puts table.tableize
+  sorted_list.each { |pr| `open #{pr["Link"]}` } if opts[:open]
 end


### PR DESCRIPTION
A simple convenience method for opening all of the existing pull requests in the browser.

Currently only works for OSX, as this makes use of the `open` shell command, and I haven't setup this for other operating systems.  We could use something like:

https://github.com/copiousfreetime/launchy

But I wasn't going to go that far for something that might not be useful to anyone else.