### PR TITLE
[fetch_repos] Add --checkout flag

### DIFF
--- a/bin/fetch_repos.rb
+++ b/bin/fetch_repos.rb
@@ -7,12 +7,16 @@ require 'manageiq/release'
 require 'trollop'
 
 opts = Trollop.options do
-  opt :branch, "The target branch", :type => :string, :required => false
+  opt :branch,   "The target branch",           :type => :string,  :required => false
+  opt :checkout, "Also checkout target branch", :type => :boolean, :default => false
 end
 
 repos = opts[:branch] ? ManageIQ::Release::Repos[opts[:branch]] : ManageIQ::Release::Repos.all_repos
 repos.each do |repo|
   puts ManageIQ::Release.header(repo.name)
   repo.fetch
+  Dir.chdir(repo.path) do
+    repo.checkout(opts[:branch])
+  end if opts[:checkout] && opts[:branch] && !repo.options["has_real_releases"]
   puts
 end


### PR DESCRIPTION
Optional flag to not only fetch the repos, but to check out the proper branch (for when doing a backporting session).

Original functionality is still the default.