### PR TITLE
Remove manageiq-providers-hawkular

### DIFF
--- a/config/labels.yml
+++ b/config/labels.yml
@@ -173,11 +173,6 @@ repos:
     <<: *feature_introduced_in_darga_or_prior
     <<: *provider_plugin
     <<: *release
-  manageiq-providers-hawkular:
-    <<: *common
-    <<: *feature_introduced_in_darga_or_prior
-    <<: *provider_plugin
-    <<: *release
   manageiq-providers-kubernetes:
     <<: *common
     <<: *feature_introduced_in_darga_or_prior

--- a/config/repos.yml
+++ b/config/repos.yml
@@ -32,7 +32,6 @@ master:
   manageiq-providers-azure:
   manageiq-providers-foreman:
   manageiq-providers-google:
-  manageiq-providers-hawkular:
   manageiq-providers-kubernetes:
   manageiq-providers-kubevirt:
   manageiq-providers-lenovo:
@@ -83,7 +82,6 @@ gaprindashvili:
   manageiq-providers-azure:
   manageiq-providers-foreman:
   manageiq-providers-google:
-  manageiq-providers-hawkular:
   manageiq-providers-kubernetes:
   manageiq-providers-lenovo:
   manageiq-providers-nuage:


### PR DESCRIPTION
Remove manageiq-providers-hawkular from the list of repos now that
https://github.com/ManageIQ/manageiq-providers-hawkular/pull/134 is
merged.