### PR TITLE
Fixes for Travis status script

### DIFF
--- a/config/repos.yml
+++ b/config/repos.yml
@@ -51,7 +51,6 @@ master:
   manageiq-v2v:
   manageiq_docs:
   ui-components:
-    has_real_releases: true
 gaprindashvili:
   container-httpd:
     has_real_releases: true


### PR DESCRIPTION
- Don't show Travis status for repos with "has_real_releases"
- Don't call repo.branches as calling that method changes the result of
repo.last_on_branch for some repos
- ui-components 'master' doesn't have actual releases, but `bower-dev` is released from tip automatically. Remove from yml, and show Travis status
- Add last build ID