### PR TITLE
Betterer Blasterer Outterer

### DIFF
--- a/bin/pull_request_blaster_outer.rb
+++ b/bin/pull_request_blaster_outer.rb
@@ -12,6 +12,8 @@ opts = Optimist.options do
   opt :script,  "The path to the script that will update the desired files.", :type => :string, :required => true
   opt :message, "The commit message and PR title for this change.",           :type => :string, :required => true
 
+  opt :labels,  "Labels to add to the PR (optional, comma delimited).",       :type => :strings
+
   opt :repo,    "The repo to update. If not passed, will try all repos in config/repos.yml.", :type => :strings
   opt :dry_run, "Make local changes, but don't fork, push, or create the pull request.", :default => false
 end

--- a/bin/pull_request_blaster_outer.rb
+++ b/bin/pull_request_blaster_outer.rb
@@ -12,6 +12,7 @@ opts = Optimist.options do
   opt :script,  "The path to the script that will update the desired files.", :type => :string, :required => true
   opt :message, "The commit message and PR title for this change.",           :type => :string, :required => true
 
+  opt :assign,  "GH user (no @) to assign to the pull requests (optional)",   :type => :string
   opt :labels,  "Labels to add to the PR (optional, comma delimited).",       :type => :strings
 
   opt :repo,    "The repo to update. If not passed, will try all repos in config/repos.yml.", :type => :strings

--- a/bin/pull_request_blaster_outer.rb
+++ b/bin/pull_request_blaster_outer.rb
@@ -12,8 +12,10 @@ opts = Optimist.options do
   opt :script,  "The path to the script that will update the desired files.", :type => :string, :required => true
   opt :message, "The commit message and PR title for this change.",           :type => :string, :required => true
 
-  opt :assign,  "GH user (no @) to assign to the pull requests (optional)",   :type => :string
-  opt :labels,  "Labels to add to the PR (optional, comma delimited).",       :type => :strings
+  opt :body,      "The Pull Request body (optional).",                        :type => :string
+  opt :body_file, "The Pull Request body, read from file (optional).",        :type => :string, :short    => 'f'
+  opt :assign,    "GH user (no @) to assign to the pull requests (optional)", :type => :string
+  opt :labels,    "Labels to add to the PR (optional, comma delimited).",     :type => :strings
 
   opt :repo,    "The repo to update. If not passed, will try all repos in config/repos.yml.", :type => :strings
   opt :dry_run, "Make local changes, but don't fork, push, or create the pull request.", :default => false

--- a/bin/pull_request_blaster_outer.rb
+++ b/bin/pull_request_blaster_outer.rb
@@ -16,10 +16,4 @@ opts = Optimist.options do
   opt :dry_run, "Make local changes, but don't fork, push, or create the pull request.", :default => false
 end
 
-results = {}
-ManageIQ::Release.each_repo(opts[:repo]) do |repo|
-  results[repo.github_repo] = ManageIQ::Release::PullRequestBlasterOuter.new(repo, opts.slice(:base, :head, :script, :dry_run, :message)).blast
-end
-
-require 'pp'
-pp results
+ManageIQ::Release::PullRequestBlasterOuter.run opts

--- a/lib/manageiq/release/pull_request_blaster_outer.rb
+++ b/lib/manageiq/release/pull_request_blaster_outer.rb
@@ -6,6 +6,19 @@ module ManageIQ
       attr_reader :repo, :base, :head, :script, :dry_run, :message
 
       ROOT_DIR = Pathname.new(__dir__).join("..", "..", "..").freeze
+
+      def self.run(opts)
+        results = {}
+
+        ManageIQ::Release.each_repo(opts[:repo]) do |repo|
+          kwargs = opts.slice(:base, :head, :script, :dry_run, :message)
+          results[repo.github_repo] = ManageIQ::Release::PullRequestBlasterOuter.new(repo, kwargs).blast
+        end
+
+        require "pp"
+        pp results
+      end
+
       def initialize(repo, base:, head:, script:, dry_run:, message:)
         @repo    = repo
         @base    = base

--- a/lib/manageiq/release/pull_request_blaster_outer.rb
+++ b/lib/manageiq/release/pull_request_blaster_outer.rb
@@ -126,11 +126,21 @@ module ManageIQ
       end
 
       def open_pull_request
-        pr = github.create_pull_request(repo.github_repo, base, pr_head, message[0,72], message[0,72])
+        pr = github.create_pull_request(*create_pull_request_args)
         pr.html_url
       rescue => err
         raise unless err.message.include?("A pull request already exists")
         puts "!!! Skipping.  #{err.message}"
+      end
+
+      def create_pull_request_args
+        [
+          repo.github_repo,
+          base,
+          pr_head,
+          message[0,72],
+          message[0,72]
+        ]
       end
     end
   end

--- a/lib/manageiq/release/pull_request_blaster_outer.rb
+++ b/lib/manageiq/release/pull_request_blaster_outer.rb
@@ -3,7 +3,7 @@ require 'pathname'
 module ManageIQ
   module Release
     class PullRequestBlasterOuter
-      attr_reader :repo, :base, :head, :script, :dry_run, :message
+      attr_reader :repo, :base, :head, :script, :dry_run, :message, :labels
 
       ROOT_DIR = Pathname.new(__dir__).join("..", "..", "..").freeze
 
@@ -11,7 +11,7 @@ module ManageIQ
         results = {}
 
         ManageIQ::Release.each_repo(opts[:repo]) do |repo|
-          kwargs = opts.slice(:base, :head, :script, :dry_run, :message)
+          kwargs = opts.slice(:base, :head, :script, :dry_run, :message, :labels)
           results[repo.github_repo] = ManageIQ::Release::PullRequestBlasterOuter.new(repo, kwargs).blast
         end
 
@@ -19,7 +19,7 @@ module ManageIQ
         pp results
       end
 
-      def initialize(repo, base:, head:, script:, dry_run:, message:)
+      def initialize(repo, base:, head:, script:, dry_run:, message:, labels:)
         @repo    = repo
         @base    = base
         @head    = head
@@ -31,6 +31,7 @@ module ManageIQ
         end
         @dry_run = dry_run
         @message = message
+        @labels  = labels
       end
 
       def blast
@@ -140,7 +141,13 @@ module ManageIQ
           pr_head,
           message[0,72],
           message[0,72]
-        ]
+        ].tap do |args|
+          options = {}
+
+          options[:labels] = labels if labels && !labels.empty?
+
+          args << options unless options.empty?
+        end
       end
     end
   end

--- a/lib/manageiq/release/pull_request_blaster_outer.rb
+++ b/lib/manageiq/release/pull_request_blaster_outer.rb
@@ -3,7 +3,7 @@ require 'pathname'
 module ManageIQ
   module Release
     class PullRequestBlasterOuter
-      attr_reader :repo, :base, :head, :script, :dry_run, :message, :labels
+      attr_reader :repo, :base, :head, :script, :dry_run, :message, :assignee, :labels
 
       ROOT_DIR = Pathname.new(__dir__).join("..", "..", "..").freeze
 
@@ -11,7 +11,7 @@ module ManageIQ
         results = {}
 
         ManageIQ::Release.each_repo(opts[:repo]) do |repo|
-          kwargs = opts.slice(:base, :head, :script, :dry_run, :message, :labels)
+          kwargs = opts.slice(:base, :head, :script, :dry_run, :message, :assign, :labels)
           results[repo.github_repo] = ManageIQ::Release::PullRequestBlasterOuter.new(repo, kwargs).blast
         end
 
@@ -19,7 +19,7 @@ module ManageIQ
         pp results
       end
 
-      def initialize(repo, base:, head:, script:, dry_run:, message:, labels:)
+      def initialize(repo, base:, head:, script:, dry_run:, message:, assign:, labels:)
         @repo    = repo
         @base    = base
         @head    = head
@@ -29,9 +29,10 @@ module ManageIQ
           raise "File not found #{s}" unless File.exist?(s)
           s.to_s
         end
-        @dry_run = dry_run
-        @message = message
-        @labels  = labels
+        @dry_run  = dry_run
+        @message  = message
+        @assignee = assign
+        @labels   = labels
       end
 
       def blast
@@ -144,7 +145,8 @@ module ManageIQ
         ].tap do |args|
           options = {}
 
-          options[:labels] = labels if labels && !labels.empty?
+          options[:assignee] = assignee if assignee
+          options[:labels]   = labels   if labels && !labels.empty?
 
           args << options unless options.empty?
         end


### PR DESCRIPTION
Very better.  Much `opts`.  Wow!

- Refactors `pull_request_blaster_outer.rb` bin file!
- Adds Label support!
- Adds Assignee support!
- Adds PR body support!

Wow!


(Serious) Note
--------------

As noted in the GitHub API docs:

https://developer.github.com/v3/issues/#create-an-issue

Both `labels` and `assignee` (and `assignees`) require that the user making the calls have "push access", which most people in this org won't have.

This leaves two options:

- If we assume the people using this script will most likely be individuals with push access, these changes work fine a is.
- If we want to open this feature up to other users, we should change up how we handle labels and assignments to have `@miq-bot` follow up the PR creation with a comment to add the desired labels and assignment.