### PR TITLE
Use ls-remote to check for remote branches

### DIFF
--- a/lib/manageiq/release/pull_request_blaster_outer.rb
+++ b/lib/manageiq/release/pull_request_blaster_outer.rb
@@ -26,13 +26,12 @@ module ManageIQ
         repo.git
         repo.fetch(output: false)
 
-        begin
-          repo.checkout(head, "origin/#{base}")
-        rescue => e
-          raise unless e.message =~ /is not a commit/
-          puts "!!! Skipping #{repo.github_repo}: #{e.message}"
+        unless repo.remote_branch?("origin", base)
+          puts "!!! Skipping #{repo.github_repo}: 'origin/#{base}' not found"
+          return
         end
 
+        repo.checkout(head, "origin/#{base}")
         run_script
 
         result = false

--- a/lib/manageiq/release/repo.rb
+++ b/lib/manageiq/release/repo.rb
@@ -65,6 +65,10 @@ module ManageIQ
         end
       end
 
+      def remote_branch?(remote, branch)
+        git.capturing.ls_remote(remote, branch).present?
+      end
+
       def write_file(file, content, dry_run: false, **kwargs)
         if dry_run
           puts "** dry-run: Writing #{path.join(file).expand_path}"


### PR DESCRIPTION
Previously, we depended on git checkout to fail with a specific
exception and error message, which could change.

It's easier to just check the remote for the branch, such as
origin/hammer and skip that repository if it doesn't have the release
branch.

It now looks like this:

```
=========================== ManageIQ/container-httpd
===========================
+++ blasting ManageIQ/container-httpd...
!!! Skipping ManageIQ/container-httpd: 'origin/hammer' not found

========================= ManageIQ/container-memcached
=========================
+++ blasting ManageIQ/container-memcached...
!!! Skipping ManageIQ/container-memcached: 'origin/hammer' not found
```