### PR TITLE
Add has_real_release to ui-components

### DIFF
--- a/config/repos.yml
+++ b/config/repos.yml
@@ -106,6 +106,7 @@ ivanchuk:
   manageiq-v2v:
   manageiq_docs:
   ui-components:
+    has_real_releases: true
 hammer:
   container-httpd:
     has_real_releases: true


### PR DESCRIPTION
ui-components is a released package, so adding `has_real_release` to ivanchuk. Not adding to `master` as we still want to create branch, add labels, etc.