### PR TITLE
PR blaster outer: Properly handle travis excludes.

### DIFF
--- a/scripts/pull_request_blaster_outer/change_travis_ruby_versions.rb
+++ b/scripts/pull_request_blaster_outer/change_travis_ruby_versions.rb
@@ -1,8 +1,9 @@
 #! /usr/bin/env ruby
-
+require "rubygems"
 versions = ENV["VERSIONS"].to_s.split(",").map(&:strip)
 if versions.empty? || versions.any? { |v| v !~ /^\d+\.\d+\.\d+$/ }
-  puts "ERROR: VERSIONS env var must be set to a comma separated list of version numbers"
+  puts "ERROR: VERSIONS env var must be set to a comma separated list of version numbers such as:"
+  puts "VERSIONS=\"2.5.7,2.6.5\" GITHUB_API_TOKEN=XXX bin/pull_request_blaster_outer.rb --base master --head update_travis_rubies --script scripts/pull_request_blaster_outer/change_travis_ruby_versions.rb --message \"Test ruby 2.5.7/2.6.5, see: ManageIQ/manageiq#19414\""
   exit 1
 end
 
@@ -12,15 +13,29 @@ unless File.exist?(travis)
   exit 0
 end
 
-travis_content = File.read(travis)
+sorted_versions = versions.sort {|x, y| Gem::Version.new(x) <=> Gem::Version.new(y)}
 
 changed = false
-versions.each do |version|
-  major_minor = version.split(".")[0, 2].join(".")
-  changed = true if travis_content.gsub!(/#{major_minor}\.[0-9]+/, version)
+
+require "yaml"
+yaml = YAML.load_file(travis)
+
+if yaml["rvm"] && yaml["rvm"] != sorted_versions
+  yaml["rvm"] = sorted_versions
+  changed = true
+end
+
+excludes = yaml["matrix"]["exclude"] if yaml["matrix"]
+if excludes.kind_of?(Array)
+  excludes.each do |exclude|
+    if exclude["rvm"] && exclude["rvm"] != sorted_versions.first
+      exclude["rvm"] = sorted_versions.first
+      changed = true
+    end
+  end
 end
 
 if changed
-  File.write(travis, travis_content)
+  File.write(travis, YAML.dump(yaml))
   puts "Wrote updated travis.yml at: #{travis}"
 end


### PR DESCRIPTION
tldr; we weren't handling the exclusions of the older ruby test runs for ui-classic, nuage, and some other repos so we'd have to update the rubies, then they'd have to go and fix the excludes after the fact. 

Use YAML to parse and dump the file instead of reading the yaml as a string and
using gsub to replace values for a few reasons:

* the blind gsub across the whole yaml string could not replace the travis excluded ruby suites
* it could gsub in the wrong places
* it could not handle if we're changing the number of rubies we want to test

Note, we can't output comments we had in our .travis.yml so any comments will
now be lost.  We don't currently have any comments so it's not a problem.

We now only update the toplevel 'rvm' key and ['matrix']['exclude'] if they
exist and populated, instead of replacing all similar looking version strings.

Finally, we now force sort of rubies in ascending order to match existing
patterns in our files.