### PR TITLE
Auto calculate next Sprint milestone

### DIFF
--- a/bin/update_sprint_milestones.rb
+++ b/bin/update_sprint_milestones.rb
@@ -7,11 +7,15 @@ require 'manageiq/release'
 require 'optimist'
 
 opts = Optimist.options do
-  opt :title, "The milestone to create", :type => :string, :required => true
+  opt :title, "The milestone to create", :type => :string
+  opt :scheduled, "Used for scheduled updates and will auto calculate the title", :default => false
 
   opt :repo, "The repo to update. If not passed, will try all repos in config/repos.yml", :type => :strings
   opt :dry_run, "", :default => false
 end
+
+opts[:title] = ManageIQ::Release::SprintMilestone.next_title if opts[:scheduled]
+Optimist.die "option --title must be specified" if opts[:title].nil?
 
 ManageIQ::Release.each_repo(opts[:repo]) do |repo|
   ManageIQ::Release::UpdateSprintMilestones.new(repo.github_repo, opts.slice(:title, :dry_run)).run

--- a/lib/manageiq/release/sprint_milestone.rb
+++ b/lib/manageiq/release/sprint_milestone.rb
@@ -13,6 +13,33 @@ module ManageIQ
       def self.valid_title?(title)
         title =~ /\ASprint \d+ Ending (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d+, 20\d\d\Z/
       end
+
+      def self.next_title
+        build_title(*sprints.first)
+      end
+
+      def self.build_title(number, date)
+        "Sprint #{number} Ending #{date.strftime("%b %-d, %Y")}"
+      end
+
+      def self.sprints(as_of: Date.today)
+        require "active_support/core_ext/numeric/time"
+        # The first date when we started doing this cadence
+        number = 76
+        date   = Date.parse("Jan 1, 2018")
+
+        Enumerator.new do |y|
+          loop do
+            y << [number, date] if date >= as_of
+
+            number += 1
+            date   += 2.weeks
+            while (date.month == 12 && (22..31).cover?(date.day)) || (date.month == 1 && (1..4).cover?(date.day))
+              date += 1.weeks
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
@bdunne Please review.

Once this is merged, we can cron this every tuesday just after midnight Eastern and it will do the right thing.  The command to run on the cron is `bin/update_sprint_milestone.rb --scheduled`

If you want to try it yourself locally just tack on a `--dry-run`

cc @himdel @mzazrivec
cc @simaishi @mfeifer