### PR TITLE
Tag amazon_ssa_support

### DIFF
--- a/config/repos.yml
+++ b/config/repos.yml
@@ -1,4 +1,5 @@
 master:
+  amazon_ssa_support:
   container-httpd:
     has_real_releases: true
   container-memcached:
@@ -53,6 +54,7 @@ master:
   manageiq_docs:
   ui-components:
 ivanchuk:
+  amazon_ssa_support:
   container-httpd:
     has_real_releases: true
   container-memcached:
@@ -108,6 +110,7 @@ ivanchuk:
   ui-components:
     has_real_releases: true
 hammer:
+  amazon_ssa_support:
   container-httpd:
     has_real_releases: true
   container-memcached:
@@ -161,6 +164,7 @@ hammer:
   ui-components:
     has_real_releases: true
 gaprindashvili:
+  amazon_ssa_support:
   container-httpd:
     has_real_releases: true
   container-memcached:


### PR DESCRIPTION
amazon_ssa_support repo is no longer 'master' only so we need to tag, etc.

We're only tagging master/ivanchuk now, but hammer/gaprindashvili branches exist in amazon_ssa_support as well, so adding them all to the yml.