### PR TITLE
container-redis repo has been archived, remove it from the config

### DIFF
--- a/config/repos.yml
+++ b/config/repos.yml
@@ -6,8 +6,6 @@ master:
     has_real_releases: true
   container-postgresql:
     has_real_releases: true
-  container-redis:
-    has_real_releases: true
   container-ruby:
     has_real_releases: true
   dbus_api_service:


### PR DESCRIPTION
The sprint milestone update PR was getting stuck on this repo with:
```
=========================== ManageIQ/container-redis ===========================
Closing "Sprint 127 Ending Jan 6, 2020"
Traceback (most recent call last):
	22: from bin/update_sprint_milestones.rb:20:in `<main>'
	21: from /opt/cfme-release/lib/manageiq/release.rb:37:in `each_repo'
	20: from /opt/cfme-release/lib/manageiq/release.rb:37:in `each'
	19: from /opt/cfme-release/lib/manageiq/release.rb:39:in `block in each_repo'
	18: from bin/update_sprint_milestones.rb:21:in `block in <main>'
	17: from /opt/cfme-release/lib/manageiq/release/update_sprint_milestones.rb:18:in `run'
	16: from /opt/cfme-release/lib/manageiq/release/update_sprint_milestones.rb:18:in `each'
	15: from /opt/cfme-release/lib/manageiq/release/update_sprint_milestones.rb:18:in `block in run'
	14: from /opt/cfme-release/lib/manageiq/release/update_sprint_milestones.rb:57:in `close'
	13: from /opt/rubies/ruby-2.5.5/lib/ruby/gems/2.5.0/gems/octokit-4.14.0/lib/octokit/client/milestones.rb:69:in `update_milestone'
	12: from /opt/rubies/ruby-2.5.5/lib/ruby/gems/2.5.0/gems/octokit-4.14.0/lib/octokit/connection.rb:46:in `patch'
	11: from /opt/rubies/ruby-2.5.5/lib/ruby/gems/2.5.0/gems/octokit-4.14.0/lib/octokit/connection.rb:156:in `request'
	10: from /opt/rubies/ruby-2.5.5/lib/ruby/gems/2.5.0/gems/sawyer-0.8.2/lib/sawyer/agent.rb:94:in `call'
	 9: from /opt/rubies/ruby-2.5.5/lib/ruby/gems/2.5.0/gems/faraday-0.17.0/lib/faraday/connection.rb:175:in `patch'
	 8: from /opt/rubies/ruby-2.5.5/lib/ruby/gems/2.5.0/gems/faraday-0.17.0/lib/faraday/connection.rb:387:in `run_request'
	 7: from /opt/rubies/ruby-2.5.5/lib/ruby/gems/2.5.0/gems/faraday-0.17.0/lib/faraday/rack_builder.rb:143:in `build_response'
	 6: from /opt/rubies/ruby-2.5.5/lib/ruby/gems/2.5.0/gems/faraday-0.17.0/lib/faraday/request/retry.rb:130:in `call'
	 5: from /opt/rubies/ruby-2.5.5/lib/ruby/gems/2.5.0/gems/octokit-4.14.0/lib/octokit/middleware/follow_redirects.rb:61:in `call'
	 4: from /opt/rubies/ruby-2.5.5/lib/ruby/gems/2.5.0/gems/octokit-4.14.0/lib/octokit/middleware/follow_redirects.rb:73:in `perform_with_redirection'
	 3: from /opt/rubies/ruby-2.5.5/lib/ruby/gems/2.5.0/gems/faraday-0.17.0/lib/faraday/response.rb:8:in `call'
	 2: from /opt/rubies/ruby-2.5.5/lib/ruby/gems/2.5.0/gems/faraday-0.17.0/lib/faraday/response.rb:61:in `on_complete'
	 1: from /opt/rubies/ruby-2.5.5/lib/ruby/gems/2.5.0/gems/faraday-0.17.0/lib/faraday/response.rb:9:in `block in call'
/opt/rubies/ruby-2.5.5/lib/ruby/gems/2.5.0/gems/octokit-4.14.0/lib/octokit/response/raise_error.rb:16:in `on_complete': PATCH https://api.github.com/repos/ManageIQ/container-redis/milestones/51: 404 - Not Found // See: https://developer.github.com/v3/issues/milestones/#update-a-milestone (Octokit::NotFound)
```