### PR TITLE
Qualify topo and sources repo paths with "RedHatInsights" to prevent defaulting to "ManageIQ"

### DIFF
--- a/config/repos.sources.yml
+++ b/config/repos.sources.yml
@@ -1,3 +1,3 @@
 sources-stable:
-  sources-api:
-  sources-monitor:
+  RedHatInsights/sources-api:
+  RedHatInsights/sources-monitor:

--- a/config/repos.topological_inventory.yml
+++ b/config/repos.topological_inventory.yml
@@ -1,14 +1,14 @@
 topological-stable:
-  topological_inventory-amazon:
-  topological_inventory-ansible_tower:
-  topological_inventory-api:
-  topological_inventory-azure:
-  topological_inventory-core:
-  topological_inventory-host_inventory_sync:
-  topological_inventory-ingress_api:
-  topological_inventory-openshift:
-  topological_inventory-orchestrator:
-  topological_inventory-persister:
-  topological_inventory-providers-common:
-  topological_inventory-satellite:
-  topological_inventory-sync:
+  RedHatInsights/topological_inventory-amazon:
+  RedHatInsights/topological_inventory-ansible_tower:
+  RedHatInsights/topological_inventory-api:
+  RedHatInsights/topological_inventory-azure:
+  RedHatInsights/topological_inventory-core:
+  RedHatInsights/topological_inventory-host_inventory_sync:
+  RedHatInsights/topological_inventory-ingress_api:
+  RedHatInsights/topological_inventory-openshift:
+  RedHatInsights/topological_inventory-orchestrator:
+  RedHatInsights/topological_inventory-persister:
+  RedHatInsights/topological_inventory-providers-common:
+  RedHatInsights/topological_inventory-satellite:
+  RedHatInsights/topological_inventory-sync:


### PR DESCRIPTION
This allows the release script to continue to work after the repo move to RedHatInsights 