### PR TITLE
Gem push to Digital Ocean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /repos
+config/settings.local.yml
 Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,9 @@
 source "https://rubygems.org"
 
 gem "activesupport",        :require => false
+gem "aws-sdk-s3",           :require => false
+gem "builder",              :require => false
+gem "config",               :require => false
 gem "licensee",             :require => false
 gem "minigit",              :require => false
 gem "more_core_extensions", :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@ source "https://rubygems.org"
 
 gem "activesupport",        :require => false
 gem "licensee",             :require => false
-gem "more_core_extensions", :require => false
 gem "minigit",              :require => false
+gem "more_core_extensions", :require => false
 gem "octokit", ">=4.7.0",   :require => false
+gem "optimist",             :require => false
 gem "rest-client",          :require => false
 gem "travis",               :require => false
-gem "optimist",             :require => false

--- a/bin/miq_gem_push.rb
+++ b/bin/miq_gem_push.rb
@@ -1,0 +1,102 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path("../lib", __dir__)
+
+require 'bundler/setup'
+require 'manageiq/release'
+require 'manageiq/release/settings'
+
+require 'aws-sdk-s3'
+require 'fileutils'
+require 'rubygems'
+require 'rubygems/package'
+require 'zlib'
+
+gems_to_push = ARGV
+raise "Please specify at least one gem" if gems_to_push.empty?
+
+client = Aws::S3::Client.new(
+  :access_key_id     => Settings.manageiq_rubygems.s3_access_key,
+  :secret_access_key => Settings.manageiq_rubygems.s3_secret_key,
+  :region            => "us-east-1",
+  :endpoint          => Settings.manageiq_rubygems.s3_endpoint
+)
+
+def ungzip(gzip)
+  reader = Zlib::GzipReader.new(gzip)
+  StringIO.new(reader.read)
+ensure
+  reader.close
+end
+
+def untar(io, destination)
+  Gem::Package::TarReader.new(io) do |tar|
+    tar.each do |entry|
+      destination_file = File.join(destination, entry.full_name)
+
+      if entry.directory?
+        FileUtils.mkdir_p(destination_file)
+      else
+        destination_directory = File.dirname(destination_file)
+        FileUtils.mkdir_p(destination_directory) unless File.directory?(destination_directory)
+        File.write(destination_file, entry.read)
+      end
+    end
+  end
+end
+
+require 'tmpdir'
+Dir.mktmpdir do |tmpdir|
+  puts "Created tempdir at #{tmpdir}"
+
+  puts "Fetching index pack..."
+  response = client.get_object(:bucket => Settings.manageiq_rubygems.s3_bucket, :key => 'index.tgz')
+
+  puts "Unpacking index pack..."
+  untar(ungzip(response.body), tmpdir)
+
+  gem_dir = File.join(tmpdir, "gems")
+  FileUtils.mkdir_p(gem_dir)
+  gems_to_push.each { |new_gem| FileUtils.cp(new_gem, gem_dir)}
+
+  puts "Updating rubygems index"
+  require "rubygems/indexer"
+  Gem::Indexer.new(tmpdir, :build_modern => true).update_index
+
+  puts "Re-generating index pack..."
+  tarfile = StringIO.new
+  Gem::Package::TarWriter.new(tarfile) do |tar_writer|
+    (Dir[File.join(tmpdir, "*specs.4.8")] + Dir[File.join(tmpdir, "quick", "**/*")]).each do |file|
+      mode = File.stat(file).mode
+      destination = file.split("#{tmpdir}/").last
+
+      if File.directory?(file)
+        tar_writer.mkdir destination, mode
+      else
+        puts "  adding file: #{destination}"
+        tar_writer.add_file(destination, mode) do |entry|
+          entry.write(File.read(file, :mode => "rb"))
+        end
+      end
+    end
+  end
+
+  tarfile.rewind
+
+  Zlib::GzipWriter.open(File.join(tmpdir, "index.tgz")) do |gz|
+    gz.write(tarfile.string)
+  end
+
+  puts "Uploading files:"
+  Dir.glob(File.join(tmpdir, "**/*")).sort.each do |file|
+    next if File.directory?(file)
+
+    destination_name = file.split("#{tmpdir}/").last
+    puts "  uploading: #{destination_name}"
+    File.open(file, 'rb') do |content|
+      client.put_object(:bucket => Settings.manageiq_rubygems.s3_bucket, :key => destination_name, :body => content, :acl => "public-read")
+    end
+  end
+
+  puts "Complete!"
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,6 @@
+---
+:manageiq_rubygems:
+  :s3_access_key:
+  :s3_secret_key:
+  :s3_endpoint: https://nyc3.digitaloceanspaces.com
+  :s3_bucket: rubygems-manageiq-org

--- a/lib/manageiq/release/settings.rb
+++ b/lib/manageiq/release/settings.rb
@@ -1,0 +1,3 @@
+require 'config'
+
+Config.load_and_set_settings(ManageIQ::Release::CONFIG_DIR.join("settings.yml").to_s, ManageIQ::Release::CONFIG_DIR.join("settings.local.yml").to_s)


### PR DESCRIPTION
Add a script to push gems to rubygems.manageiq.org

From the root:
`bin/miq_gem_push.rb /path/to/some_gem-1.2.3.gem /path/to/next_gem-2.3.4.gem ...etc`

Sample output:
```
Created tempdir at /tmp/d20200422-637254-c7x6fj
Fetching index pack...
Unpacking index pack...
Updating rubygems index
Generating Marshal quick index gemspecs for 1 gems
.
Complete
Generated Marshal quick index gemspecs: 0.001s
Updated indexes: 0.000s
Compressing indices
Compressed indices: 0.000s
Re-generating index pack...
  adding file: prerelease_specs.4.8
  adding file: latest_specs.4.8
  adding file: specs.4.8
  adding file: quick/Marshal.4.8/handsoap-0.2.5.5.gemspec.rz
  adding file: quick/Marshal.4.8/jquery-rjs-0.1.1.1.gemspec.rz
  adding file: quick/Marshal.4.8/rugged-0.28.2.2.gemspec.rz
  adding file: quick/Marshal.4.8/ruport-1.7.0.3.gemspec.rz
Uploading files:
  uploading: gems/handsoap-0.2.5.5.gem
  uploading: index.tgz
  uploading: latest_specs.4.8
  uploading: latest_specs.4.8.gz
  uploading: prerelease_specs.4.8
  uploading: prerelease_specs.4.8.gz
  uploading: quick/Marshal.4.8/handsoap-0.2.5.5.gemspec.rz
  uploading: quick/Marshal.4.8/jquery-rjs-0.1.1.1.gemspec.rz
  uploading: quick/Marshal.4.8/rugged-0.28.2.2.gemspec.rz
  uploading: quick/Marshal.4.8/ruport-1.7.0.3.gemspec.rz
  uploading: specs.4.8
  uploading: specs.4.8.gz
Complete!

```