### PR TITLE
Remove no longer used host_inventory_sync from deployment

### DIFF
--- a/config/repos.topological_inventory.yml
+++ b/config/repos.topological_inventory.yml
@@ -4,7 +4,6 @@ topological-stable:
   RedHatInsights/topological_inventory-api:
   RedHatInsights/topological_inventory-azure:
   RedHatInsights/topological_inventory-core:
-  RedHatInsights/topological_inventory-host_inventory_sync:
   RedHatInsights/topological_inventory-ingress_api:
   RedHatInsights/topological_inventory-openshift:
   RedHatInsights/topological_inventory-orchestrator:


### PR DESCRIPTION
host_inventory_sync repo is no longer used, so removing it from the list up updated repos when we push to stable.