### PR TITLE
Standardize on repo_set terminology

### DIFF
--- a/bin/destroy_branch.rb
+++ b/bin/destroy_branch.rb
@@ -7,13 +7,12 @@ require 'manageiq/release'
 require 'optimist'
 
 opts = Optimist.options do
-  opt :branch, "The target branch", :type => :string, :required => true
+  opt :branch, "The branch to destroy.", :type => :string, :required => true
+
+  ManageIQ::Release.common_options(self, :except => :dry_run)
 end
 
-repos = ManageIQ::Release::Repos["master"]
-repos.each do |repo|
-  puts ManageIQ::Release.header("Destroying #{repo.name}")
-
+ManageIQ::Release.each_repo(opts) do |repo|
   repo.chdir do
     system("git checkout master")
     system("git branch -D #{opts[:branch]}")

--- a/bin/fetch_repos.rb
+++ b/bin/fetch_repos.rb
@@ -7,16 +7,14 @@ require 'manageiq/release'
 require 'optimist'
 
 opts = Optimist.options do
-  opt :branch,   "The target branch",           :type => :string,  :required => false
-  opt :checkout, "Also checkout target branch", :type => :boolean, :default => false
-end
+  opt :branch,   "The branch to fetch.",                   :type => :string,  :required => true
+  opt :checkout, "Checkout target branch after fetching.", :type => :boolean, :default => false
 
-repos = opts[:branch] ? ManageIQ::Release::Repos[opts[:branch]] : ManageIQ::Release::Repos.all_repos
-repos.each do |repo|
-  puts ManageIQ::Release.header(repo.name)
+  ManageIQ::Release.common_options(self, :except => :dry_run, :repo_set_default => nil)
+end
+opts[:repo_set] = opts[:branch] unless opts[:repo] || opts[:repo_set]
+
+ManageIQ::Release.each_repo(opts) do |repo|
   repo.fetch
-  repo.chdir do
-    repo.checkout(opts[:branch])
-  end if opts[:checkout] && opts[:branch] && !repo.options["has_real_releases"]
-  puts
+  repo.checkout(opts[:branch]) if opts[:checkout] && opts[:branch] && !repo.options.has_real_releases
 end

--- a/bin/list_backport_pr.rb
+++ b/bin/list_backport_pr.rb
@@ -8,9 +8,10 @@ require 'more_core_extensions/core_ext/array/tableize'
 require 'optimist'
 
 opts = Optimist.options do
-  opt :blocker, "List 'blocker' PRs only",          :type => :boolean, :default => false
-  opt :branch,  "The target branch to backport to", :type => :string,  :required => true
-  opt :open,    "Open all links in a browser",      :type => :boolean, :default => false
+  opt :branch,  "The target branch to backport to.", :type => :string,  :required => true
+
+  opt :blocker, "List 'blocker' PRs only.",          :type => :boolean, :default => false
+  opt :open,    "Open all links in a browser.",      :type => :boolean, :default => false
 end
 
 branch = opts[:branch]

--- a/bin/new_plugin_repo.rb
+++ b/bin/new_plugin_repo.rb
@@ -7,9 +7,7 @@ require 'manageiq/release'
 require 'optimist'
 
 opts = Optimist.options do
-  opt :repo, "The repo to update.", :required => true, :type => :string
-
-  opt :dry_run, "", :default => false
+  ManageIQ::Release.common_options(self, :except => :repo_set)
 end
 
 repo = ManageIQ::Release.repo_for(opts[:repo])

--- a/bin/pull_request_blaster_outer.rb
+++ b/bin/pull_request_blaster_outer.rb
@@ -7,17 +7,16 @@ require 'manageiq/release'
 require 'optimist'
 
 opts = Optimist.options do
-  opt :base,    "The name of the branch you want the changes pulled into.",   :type => :string, :required => true
-  opt :head,    "The name of the branch containing the changes.",             :type => :string, :required => true
+  opt :base,    "The target branch for the changes.",                         :type => :string, :required => true
+  opt :head,    "The name of the branch to create on your fork.",             :type => :string, :required => true
   opt :script,  "The path to the script that will update the desired files.", :type => :string, :required => true
   opt :message, "The commit message and PR title for this change.",           :type => :string, :required => true
 
-  opt :repo,    "The repo to update. If not passed, will try all repos in config/repos.yml.", :type => :strings
-  opt :dry_run, "Make local changes, but don't fork, push, or create the pull request.", :default => false
+  ManageIQ::Release.common_options(self)
 end
 
 results = {}
-ManageIQ::Release.each_repo(opts[:repo]) do |repo|
+ManageIQ::Release.each_repo(opts) do |repo|
   results[repo.github_repo] = ManageIQ::Release::PullRequestBlasterOuter.new(repo, opts.slice(:base, :head, :script, :dry_run, :message)).blast
 end
 

--- a/bin/release_branch.rb
+++ b/bin/release_branch.rb
@@ -7,16 +7,16 @@ require 'manageiq/release'
 require 'optimist'
 
 opts = Optimist.options do
-  opt :branch, "The new branch name", :type => :string, :required => true
-end
+  opt :branch, "The new branch name.", :type => :string, :required => true
 
-repos = ManageIQ::Release::Repos["master"]
+  ManageIQ::Release.common_options(self, :except => :dry_run) # TODO: Implement dry_run
+end
 
 review = StringIO.new
 post_review = StringIO.new
 
-repos.each do |repo|
-  next if repo.options["has_real_releases"]
+ManageIQ::Release.repos_for(opts).each do |repo|
+  next if repo.options.has_real_releases
 
   release_branch = ManageIQ::Release::ReleaseBranch.new(repo, opts.slice(:branch))
 

--- a/bin/release_microservice.rb
+++ b/bin/release_microservice.rb
@@ -7,12 +7,10 @@ require 'manageiq/release'
 require 'optimist'
 
 opts = Optimist.options do
-  opt :repo_set, "The repo set", :type => :string,  :required => true
-  opt :dry_run,  "",             :default => true
+  ManageIQ::Release.common_options(self)
 end
 
-ManageIQ::Release::Repos[opts[:repo_set]].each do |repo|
-  puts ManageIQ::Release.header(repo.name)
+ManageIQ::Release.each_repo(opts) do |repo|
   repo.fetch
   repo.chdir do
     repo.checkout("stable", "origin/stable")
@@ -24,6 +22,5 @@ ManageIQ::Release::Repos[opts[:repo_set]].each do |repo|
       repo.git.push("origin", "stable")
     end
   end
-  puts
 end
 

--- a/bin/release_milestone.rb
+++ b/bin/release_milestone.rb
@@ -7,16 +7,13 @@ require 'manageiq/release'
 require 'optimist'
 
 opts = Optimist.options do
-  opt :repo,   "The repo to update. If not passed, will try all repos in config/repos.yml", :type => :strings
+  opt :title,  "The new milestone title.",    :type => :string, :required => true
+  opt :due_on, "The new milestone due date.", :type => :string, :required => true
 
-  opt :title,  "The new milestone title",    :type => :string, :required => true
-  opt :due_on, "The new milestone due date", :type => :string, :required => true
-
-  opt :dry_run, "", :default => false
+  ManageIQ::Release.common_options(self)
 end
-
 Optimist.die(:due_on, "must be a date format") unless ManageIQ::Release::ReleaseMilestone.valid_date?(opts[:due_on])
 
-ManageIQ::Release.each_repo(opts[:repo]) do |repo|
+ManageIQ::Release.each_repo(opts) do |repo|
   ManageIQ::Release::ReleaseMilestone.new(repo, opts.slice(:title, :due_on, :dry_run)).run
 end

--- a/bin/release_tag.rb
+++ b/bin/release_tag.rb
@@ -7,20 +7,20 @@ require 'manageiq/release'
 require 'optimist'
 
 opts = Optimist.options do
-  opt :tag,    "The new tag name",  :type => :string, :required => true
-  opt :branch, "The target branch", :type => :string, :required => true
+  opt :tag,    "The new tag name.",       :type => :string, :required => true
+  opt :branch, "The branch to tag from.", :type => :string
 
-  opt :dry_run, "", :default => false
+  ManageIQ::Release.common_options(self, :repo_set_default => nil)
 end
-
-repos = ManageIQ::Release::Repos[opts[:branch]]
-Optimist.die "Repo #{opts[:branch].inspect} does not exist in repos.yml" if repos.nil?
+opts[:branch] ||= opts[:tag].split("-").first
+opts[:repo_set] = opts[:branch] unless opts[:repo] || opts[:repo_set]
 
 review = StringIO.new
 post_review = StringIO.new
 
-repos.each do |repo|
-  next if repo.options["has_real_releases"]
+ManageIQ::Release.repos_for(opts).each do |repo|
+  next if repo.options.has_real_releases
+
   release_tag = ManageIQ::Release::ReleaseTag.new(repo, opts.slice(:branch, :tag, :dry_run))
 
   puts ManageIQ::Release.header("Tagging #{repo.name}")

--- a/bin/rename_labels.rb
+++ b/bin/rename_labels.rb
@@ -5,17 +5,19 @@ $LOAD_PATH << File.expand_path("../lib", __dir__)
 require 'bundler/setup'
 require 'manageiq/release'
 require 'optimist'
+require 'pp'
 
 opts = Optimist.options do
-  opt :new,  "The new label name", :type => :string, :required => true
-  opt :old,  "The old label name", :type => :string, :required => true
+  opt :old, "The old label names.", :type => :strings, :required => true
+  opt :new, "The new label names.", :type => :strings, :required => true
 
-  opt :repo, "The repo to update. If not passed, will try all repos in config/repos.yml", :type => :strings
-  opt :dry_run, "", :default => false
+  ManageIQ::Release.common_options(self)
 end
 
-rename_hash = { opts[:old] => opts[:new] }
+rename_hash = opts[:old].zip(opts[:new]).to_h
+puts "Renaming: #{rename_hash.pretty_inspect}"
+puts
 
-ManageIQ::Release.each_repo(opts[:repo]) do |repo|
+ManageIQ::Release.each_repo(opts) do |repo|
   ManageIQ::Release::RenameLabels.new(repo.github_repo, rename_hash, opts.slice(:dry_run)).run
 end

--- a/bin/show_repo_set.rb
+++ b/bin/show_repo_set.rb
@@ -7,7 +7,7 @@ require 'manageiq/release'
 require 'optimist'
 
 opts = Optimist.options do
-  opt :branch, "The target branch", :type => :string, :required => true
+  ManageIQ::Release.common_options(self, :only => :repo_set)
 end
 
-puts ManageIQ::Release::Repos[opts[:branch]].collect(&:name)
+puts ManageIQ::Release.repos_for(opts).collect(&:name)

--- a/bin/show_tag.rb
+++ b/bin/show_tag.rb
@@ -8,18 +8,26 @@ require 'more_core_extensions/core_ext/array/tableize'
 require 'optimist'
 
 opts = Optimist.options do
-  opt :tag,    "The tag name",      :type => :string, :required => true
-  opt :branch, "The target branch", :type => :string, :required => true
+  opt :tag, "The tag name.", :type => :string, :required => true
+
+  ManageIQ::Release.common_options(self, :except => :dry_run, :repo_set_default => nil)
 end
+opts[:repo_set] = opts[:tag].split("-").first unless opts[:repo] || opts[:repo_set]
 
 HEADER = %w(Repo SHA Message).freeze
 
 def show_tag(repo, tag)
-  line = repo.git.capturing.show({:summary => true, :oneline => true}, tag)
+  line =
+    begin
+      repo.git.capturing.show({:summary => true, :oneline => true}, tag)
+    rescue MiniGit::GitError => err
+      ""
+    end
+
   sha, message = line.split(" ", 2)
   [repo.name, sha, message]
 end
 
-repos = ManageIQ::Release::Repos[opts[:branch]]
+repos = ManageIQ::Release.repos_for(opts).reject { |repo| repo.options.has_real_releases }
 table = [HEADER] + repos.collect { |repo| show_tag(repo, opts[:tag]) }
 puts table.tableize(:max_width => 75)

--- a/bin/update_labels.rb
+++ b/bin/update_labels.rb
@@ -7,11 +7,10 @@ require 'manageiq/release'
 require 'optimist'
 
 opts = Optimist.options do
-  opt :repo, "The repo to update. If not passed, will try all repos in config/labels.yml", :type => :strings
-  opt :dry_run, "", :default => false
+  ManageIQ::Release.common_options(self, :repo_set_default => nil)
 end
-opts[:repo] ||= ManageIQ::Release::Labels.all.keys
+opts[:repo] = ManageIQ::Release::Labels.all.keys.sort unless opts[:repo] || opts[:repo_set]
 
-ManageIQ::Release.each_repo(opts[:repo]) do |repo|
+ManageIQ::Release.each_repo(opts) do |repo|
   ManageIQ::Release::UpdateLabels.new(repo.github_repo, opts.slice(:dry_run)).run
 end

--- a/bin/update_repo_settings.rb
+++ b/bin/update_repo_settings.rb
@@ -7,16 +7,9 @@ require 'manageiq/release'
 require 'optimist'
 
 opts = Optimist.options do
-  opt :branch, "The branch to protect.", :type => :string
-
-  opt :repo, "The repo to update. If not passed, will try all repos for the branch specified.", :type => :strings
-  opt :dry_run, "", :default => false
+  ManageIQ::Release.common_options(self)
 end
-Optimist.die("Must pass either --repo or --branch") unless opts[:branch_given] || opts[:repo_given]
 
-ManageIQ::Release.each_repo(opts[:repo], opts[:branch]) do |repo|
+ManageIQ::Release.each_repo(opts) do |repo|
   ManageIQ::Release::UpdateRepoSettings.new(repo.github_repo, opts.slice(:dry_run)).run
-
-  skip = !opts[:branch_given] || (opts[:branch] != "master" && repo.options[:has_real_releases])
-  ManageIQ::Release::UpdateBranchProtection.new(repo.github_repo, opts.slice(:branch, :dry_run)).run unless skip
 end

--- a/bin/update_sources_for_new_branch.rb
+++ b/bin/update_sources_for_new_branch.rb
@@ -7,15 +7,16 @@ require 'manageiq/release'
 require 'optimist'
 
 opts = Optimist.options do
-  opt :branch, "The new branch name", :type => :string, :required => true
-end
+  opt :branch, "The new branch name.", :type => :string, :required => true
 
-repos = ManageIQ::Release::Repos["master"]
+  ManageIQ::Release.common_options(self, :repo_set_default => nil)
+end
+opts[:repo_set] = opts[:branch] unless opts[:repo] || opts[:branch]
+
 review = StringIO.new
 post_review = StringIO.new
 
-repos.each do |repo|
-  puts ManageIQ::Release.header("Updating #{repo.name}")
+ManageIQ::Release.each_repo(opts) do |repo|
   repo.chdir do
     repo.fetch
     repo.checkout(opts[:branch])

--- a/lib/manageiq/release.rb
+++ b/lib/manageiq/release.rb
@@ -2,7 +2,7 @@ require 'pathname'
 
 require 'manageiq/release/labels'
 require 'manageiq/release/repo'
-require 'manageiq/release/repos'
+require 'manageiq/release/repo_set'
 
 require 'manageiq/release/code_climate'
 require 'manageiq/release/hakiri'
@@ -30,26 +30,55 @@ module ManageIQ
     # CLI helpers
     #
 
-    def self.each_repo(repo_names, branch = "master")
+    def self.each_repo(**kwargs)
       raise "no block given" unless block_given?
-      repos_for(repo_names, branch).each do |repo|
+
+      repos_for(**kwargs).each do |repo|
         puts header(repo.github_repo)
         yield repo
         puts
       end
     end
 
-    def self.repos_for(repo_names, branch = "master")
-      if repo_names
-        Array(repo_names).map { |n| repo_for(n) }
+    def self.repos_for(repo: nil, repo_set: nil, **_)
+      Optimist.die("options --repo or --repo_set must be specified") unless repo || repo_set
+
+      if repo
+        Array(repo).map { |n| repo_for(n) }
       else
-        ManageIQ::Release::Repos[branch]
+        ManageIQ::Release::RepoSet[repo_set]
       end
     end
 
-    def self.repo_for(repo_name)
-      org, repo = repo_name.split("/").unshift(nil).last(2)
-      ManageIQ::Release::Repo.new(repo, :org => org)
+    def self.repo_for(repo)
+      Optimist.die(:repo, "must be specified") if repo.nil?
+
+      org, repo_name = repo.split("/").unshift(nil).last(2)
+      ManageIQ::Release::Repo.new(repo_name, :org => org)
+    end
+
+    def self.common_options(optimist, only: %i[repo repo_set dry_run], except: nil, repo_set_default: "master")
+      optimist.banner("")
+      optimist.banner("Common Options:")
+
+      subset = Array(only).map(&:to_sym) - Array(except).map(&:to_sym)
+
+      if subset.include?(:repo_set)
+        optimist.opt :repo_set, "The repo set to work with.", :default => repo_set_default, :short => "s"
+      end
+      if subset.include?(:repo)
+        msg = "Individual repo(s) to work with."
+        if subset.include?(:repo_set)
+          sub_opts = {}
+          msg << " Overrides --repo-set."
+        else
+          sub_opts = {:required => true}
+        end
+        optimist.opt :repo, msg, sub_opts.merge(:type => :strings)
+      end
+      if subset.include?(:dry_run)
+        optimist.opt :dry_run, "Execute without making changes.", :default => false
+      end
     end
 
     #

--- a/lib/manageiq/release/destroy_tag.rb
+++ b/lib/manageiq/release/destroy_tag.rb
@@ -3,7 +3,7 @@ module ManageIQ
     class DestroyTag
       attr_reader :repo, :tag
 
-      def initialize(repo, tag)
+      def initialize(repo, tag:)
         @repo = repo
         @tag = tag
       end

--- a/lib/manageiq/release/release_branch.rb
+++ b/lib/manageiq/release/release_branch.rb
@@ -1,7 +1,7 @@
 module ManageIQ
   module Release
     class ReleaseBranch
-      attr_reader :repo, :branch, :dry_run
+      attr_reader :repo, :branch
 
       def initialize(repo, branch:)
         @repo    = repo

--- a/lib/manageiq/release/repo_set.rb
+++ b/lib/manageiq/release/repo_set.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/enumerable'
 
 module ManageIQ
   module Release
-    class Repos
+    class RepoSet
       def self.[](branch)
         all[branch]
       end


### PR DESCRIPTION
Introduces ManageIQ::Release.common_options for things like repo_set,
repo, and dry_run, and then changes each_repo and repos_for to work with
these common options.

Fixes #136

Example of `--help` with these changes:

```shell
$ bin/release_tag.rb --help
Options:
  -t, --tag=<s>       The new tag name.
  -b, --branch=<s>    The branch to tag from.

Common Options:
  -s, --repo-set      The repo set to work with.
  -r, --repo=<s+>     Individual repo(s) to work with. Overrides --repo-set.
  -d, --dry-run       Execute without making changes.
  -h, --help          Show this message
```

@simaishi Please review