### PR TITLE
Allow mirror on repos that don't start with manageiq-

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/mirrors
 /repos
 config/settings.local.yml
 Gemfile.lock

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,41 +6,41 @@
   :remotes:
     :upstream: git@github.com:ManageIQ
   :repos_to_mirror:
-    manageiq-api: :upstream
-    manageiq-appliance-build: :upstream
-    manageiq-appliance: :upstream
-    manageiq-automation_engine: :upstream
-    manageiq-consumption: :upstream
-    manageiq-content: :upstream
-    manageiq-decorators: :upstream
-    manageiq-documentation: :upstream
-    manageiq-gems-pending: :upstream
-    manageiq-graphql: :upstream
-    manageiq-pods: :upstream
-    manageiq-providers-amazon: :upstream
-    manageiq-providers-ansible_tower: :upstream
-    manageiq-providers-azure: :upstream
-    manageiq-providers-azure_stack: :upstream
-    manageiq-providers-foreman: :upstream
-    manageiq-providers-google: :upstream
-    manageiq-providers-hawkular: :upstream
-    manageiq-providers-kubernetes: :upstream
-    manageiq-providers-kubevirt: :upstream
-    manageiq-providers-lenovo: :upstream
-    manageiq-providers-nuage: :upstream
-    manageiq-providers-openshift: :upstream
-    manageiq-providers-openstack: :upstream
-    manageiq-providers-ovirt: :upstream
-    manageiq-providers-redfish: :upstream
-    manageiq-providers-scvmm: :upstream
-    manageiq-providers-vmware: :upstream
-    manageiq-release: :upstream
-    manageiq-schema: :upstream
-    manageiq-ui-classic: :upstream
-    manageiq-ui-service: :upstream
-    manageiq-v2v: :upstream
-    manageiq: :upstream
-  :working_directory: ''
+    manageiq-api:
+    manageiq-appliance-build:
+    manageiq-appliance:
+    manageiq-automation_engine:
+    manageiq-consumption:
+    manageiq-content:
+    manageiq-decorators:
+    manageiq-documentation:
+    manageiq-gems-pending:
+    manageiq-graphql:
+    manageiq-pods:
+    manageiq-providers-amazon:
+    manageiq-providers-ansible_tower:
+    manageiq-providers-azure:
+    manageiq-providers-azure_stack:
+    manageiq-providers-foreman:
+    manageiq-providers-google:
+    manageiq-providers-hawkular:
+    manageiq-providers-kubernetes:
+    manageiq-providers-kubevirt:
+    manageiq-providers-lenovo:
+    manageiq-providers-nuage:
+    manageiq-providers-openshift:
+    manageiq-providers-openstack:
+    manageiq-providers-ovirt:
+    manageiq-providers-redfish:
+    manageiq-providers-scvmm:
+    manageiq-providers-vmware:
+    manageiq-release:
+    manageiq-schema:
+    manageiq-ui-classic:
+    manageiq-ui-service:
+    manageiq-v2v:
+    manageiq:
+  :working_directory: mirrors
 :manageiq_rubygems:
   :s3_access_key:
   :s3_secret_key:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,0 +1,15 @@
+---
+:git_mirror:
+  :branch_mirror_defaults:
+    jansa: j
+    master: k
+  :branch_mirror_overrides:
+    container-httpd:
+      jansa:
+      master:
+  :productization_name: foo
+  :remotes:
+    :downstream: git@github.com:miq-test
+  :repos_to_mirror:
+    container-httpd:
+      :downstream_repo_name: foo-container-httpd


### PR DESCRIPTION
@bdunne Please review.

What this change does is change the value side of the repos in the settings to be a Hash, which allows us to override things.

For example, the current settings has:

```yaml
:git_mirror:
  :repos_to_mirror:
    manageiq-api: :upstream
```

In this PR, for convenience, I've made it so the remote_source is now defaulted to `:upstream`, but if one chose to specify it they would now do:

```yaml
:git_mirror:
  :repos_to_mirror:
    manageiq-api:
      :remote_source: :upstream # or some other source
```

So, once you have a Hash, then we can allow overriding the downstream_repo_name like so:

```yaml
:git_mirror:
  :repos_to_mirror:
    container-httpd:
      :downstream_repo_name: productized-container-httpd
```

cc @bennett-white
