### PR TITLE
More changes for converting branch to repo_set

### DIFF
--- a/lib/manageiq/release/repo_set.rb
+++ b/lib/manageiq/release/repo_set.rb
@@ -4,14 +4,14 @@ require 'active_support/core_ext/enumerable'
 module ManageIQ
   module Release
     class RepoSet
-      def self.[](branch)
-        all[branch]
+      def self.[](set_name)
+        all[set_name]
       end
 
       def self.all
         @all ||=
-          config.each_with_object({}) do |(branch, repos), h|
-            h[branch] = repos.map { |name, options| Repo.new(name, options) }
+          config.each_with_object({}) do |(set_name, repos), h|
+            h[set_name] = repos.map { |name, options| Repo.new(name, options) }
           end
       end
 

--- a/lib/manageiq/release/repo_set.rb
+++ b/lib/manageiq/release/repo_set.rb
@@ -15,10 +15,6 @@ module ManageIQ
           end
       end
 
-      def self.all_repos
-        all.values.flatten.index_by(&:name).values
-      end
-
       def self.config
         @config ||= ManageIQ::Release.load_config_file("repos")
       end


### PR DESCRIPTION
@simaishi Please review.

This fixes the one variable naming.

Additionally, this drops all_repos, as it is confusing with repo_sets to have a way to break out of repo_sets.  This method was originally a helper for the labels but that has a dedicated list now