### PR TITLE
Tag 'manageiq' repo last

### DIFF
--- a/bin/release_tag.rb
+++ b/bin/release_tag.rb
@@ -18,7 +18,12 @@ opts[:repo_set] = opts[:branch] unless opts[:repo] || opts[:repo_set]
 review = StringIO.new
 post_review = StringIO.new
 
-ManageIQ::Release.repos_for(opts).each do |repo|
+# Move manageiq repo to the end of the list.  The rake release script on manageiq
+#   depends on all of the other repos running their rake release scripts first.
+repos = ManageIQ::Release.repos_for(opts)
+repos = repos.partition { |r| r.github_repo != "ManageIQ/manageiq" }.flatten
+
+repos.each do |repo|
   next if repo.options.has_real_releases
 
   release_tag = ManageIQ::Release::ReleaseTag.new(repo, opts)


### PR DESCRIPTION
When tagging repos, 'manageiq' repo needs to be handled last to ensure release task (updating Gemfile.lock.release) will use the correct branch with latest revision (see https://github.com/ManageIQ/manageiq/pull/20522)

Currently there are 2 repos that gets affected:
- manageiq-appliance - 'manageiq' release task symlink manageiq-appliance-dependencies.rb
- manageiq-content - 'manageiq-content' release task updates version and commits yml file

Even with this change, manageiq-content revision won't be accurate in Gemfile.lock.update. release_tag.rb currently runs release tasks and tag, but won't push. It will print out push command lines and it's a manual push after reviewing the changes.

The workaround can be to run release_task.rb for manageiq-content first, then run the script again for all repos (need to make sure content repo is skipped and doesn't kill the script).

Not sure if there is a way to do this all in one-shot...

