### PR TITLE
Set repo_set option to string type

### DIFF
--- a/lib/manageiq/release.rb
+++ b/lib/manageiq/release.rb
@@ -64,7 +64,7 @@ module ManageIQ
       subset = Array(only).map(&:to_sym) - Array(except).map(&:to_sym)
 
       if subset.include?(:repo_set)
-        optimist.opt :repo_set, "The repo set to work with.", :default => repo_set_default, :short => "s"
+        optimist.opt :repo_set, "The repo set to work with.", :type => :string, :default => repo_set_default, :short => "s"
       end
       if subset.include?(:repo)
         msg = "Individual repo(s) to work with."


### PR DESCRIPTION
In some scripts (e.g. bin/destroy_tag.rb), the `repo_set_default` is set to nil. When the script is called with repo set option, `opts[:repo_set]` gets set to 'true' rather than the actual string value.