### PR TITLE
Add an option to skip repos when tagging

### DIFF
--- a/bin/release_tag.rb
+++ b/bin/release_tag.rb
@@ -9,6 +9,7 @@ require 'optimist'
 opts = Optimist.options do
   opt :tag,    "The new tag name.",       :type => :string, :required => true
   opt :branch, "The branch to tag from.", :type => :string
+  opt :skip,   "The repo(s) to skip.",    :type => :strings
 
   ManageIQ::Release.common_options(self, :repo_set_default => nil)
 end
@@ -24,6 +25,7 @@ repos = ManageIQ::Release.repos_for(opts)
 repos = repos.partition { |r| r.github_repo != "ManageIQ/manageiq" }.flatten
 
 repos.each do |repo|
+  next if Array(opts[:skip]).include?(repo.name)
   next if repo.options.has_real_releases
 
   release_tag = ManageIQ::Release::ReleaseTag.new(repo, opts)


### PR DESCRIPTION
I'm adding this option for now, so I can tag 'manageiq-content' repo first, then tag the rest skipping the content repo.

Related to https://github.com/ManageIQ/manageiq-release/pull/155.

I'm thinking it might be a good idea to add a prompt in release_tag.rb to review and push manageiq-content (or any other repos with certain option) and continue so releasing tag will still be calling the script once. But I don't want that to block jansa release builds, so adding skip option here.

