### PR TITLE
Reverse lookup PR titles in show_commit_history

### DIFF
--- a/bin/show_commit_history.rb
+++ b/bin/show_commit_history.rb
@@ -6,15 +6,21 @@ require 'bundler/setup'
 require 'manageiq/release'
 require 'optimist'
 
+DISPLAY_FORMATS = %w[commit pr-title pr-label]
+
 opts = Optimist.options do
-  opt :from, "The commit log 'from' ref", :type => :string,  :required => true
-  opt :to,   "The commit log 'to' ref" ,  :type => :string,  :required => true
-  opt :skip, "The repos to skip",         :type => :strings, :default => ["manageiq-documentation"]
+  opt :from,    "The commit log 'from' ref", :type => :string,  :required => true
+  opt :to,      "The commit log 'to' ref" ,  :type => :string,  :required => true
+  opt :display, "How to display the history. Valid values are: #{DISPLAY_FORMATS.join(", ")}", :default => "commit"
+
+  opt :skip,   "The repos to skip", :default => ["manageiq-documentation"]
 
   ManageIQ::Release.common_options(self, :except => :dry_run)
 end
+Optimist.die :display, "must be one of: #{DISPLAY_FORMATS.join(", ")}" unless DISPLAY_FORMATS.include?(opts[:display])
 
 range = "#{opts[:from]}..#{opts[:to]}"
+github = ManageIQ::Release.github
 
 puts "Git commit log between #{opts[:from]} and #{opts[:to]}\n\n"
 
@@ -24,6 +30,38 @@ ManageIQ::Release.repos_for(opts).each do |repo|
 
   puts ManageIQ::Release.header(repo.name)
   repo.fetch(output: false)
-  repo.git.log({:oneline => true, :decorate => true, :reverse => true}, range)
-  puts "\n\n"
+
+  case opts[:display]
+  when "pr-label", "pr-title"
+    pr_label_display = opts[:display] == "pr-label"
+
+    results = {}
+    if pr_label_display
+      results["bug"] = []
+      results["enhancement"] = []
+    end
+    results["other"] = []
+
+    log = repo.git.capturing.log({:oneline => true}, range)
+    log.lines.each do |line|
+      next unless (match = line.match(/Merge pull request #(\d+)\b/))
+
+      pr = github.pull_request(repo.github_repo, match[1])
+      label = pr.labels.detect { |l| results.key?(l.name) }&.name || "other"
+      results[label] << pr
+    end
+
+    results.each do |label, prs|
+      next if prs.blank?
+
+      puts "\n## #{label.titleize}\n\n" if pr_label_display
+      prs.each do |pr|
+        puts "* #{pr.title} [[##{pr.number}]](#{pr.html_url})"
+      end
+    end
+  when "commit"
+    repo.git.git([{:no_pager => true}, :log, {:oneline => true, :decorate => true, :graph => true}], range)
+  end
+
+  puts
 end


### PR DESCRIPTION
Alternative to #157 

### output with `--display pr-title`

```text
bin/show_commit_history.rb --from jansa-1-rc1 --to jansa-1 --repo-set jansa --skip amazon_ssa_support --display pr-title
Git commit log between jansa-1-rc1 and jansa-1

=================================== manageiq ===================================
* [JANSA] Add jansa-1-rc2 Gemfile.lock as Gemfile.lock.release [[#20545]](https://github.com/ManageIQ/manageiq/pull/20545)
* Update Gemfile.lock.release when tagging branch [[#20522]](https://github.com/ManageIQ/manageiq/pull/20522)
* Add ability to detect and cleanup failed deployments [[#20444]](https://github.com/ManageIQ/manageiq/pull/20444)
* Cleanup failed systemd services [[#20420]](https://github.com/ManageIQ/manageiq/pull/20420)
* [AuthenticationMixin] Fix .authentication_status [[#20494]](https://github.com/ManageIQ/manageiq/pull/20494)
* enhance error handle for failing playbook clone [[#20232]](https://github.com/ManageIQ/manageiq/pull/20232)
* Updated vm_reconfigure_task in app/models to add disk Type information. [[#20081]](https://github.com/ManageIQ/manageiq/pull/20081)
* log warning if creation of task to generate widget was skipped [[#20505]](https://github.com/ManageIQ/manageiq/pull/20505)
* add ids to the retirement log lines [[#20507]](https://github.com/ManageIQ/manageiq/pull/20507)
* MiqSmartProxyWorker not running in Podified [[#20497]](https://github.com/ManageIQ/manageiq/pull/20497)
* Add supports_create_security_group virtual attribute [[#20482]](https://github.com/ManageIQ/manageiq/pull/20482)
* Allow services to set a queue_name for VM provisioning. [[#20468]](https://github.com/ManageIQ/manageiq/pull/20468)
* Improvement to action_check_compliance to avoid infinite loop. [[#20426]](https://github.com/ManageIQ/manageiq/pull/20426)
* Don't disconnect resource pools in refresh_new_target [[#20441]](https://github.com/ManageIQ/manageiq/pull/20441)
* Don't allow kafka exceptions to cause EmsEvent.add_queue to fail [[#20440]](https://github.com/ManageIQ/manageiq/pull/20440)
* Block attempt to create duplicate retire request  [[#20355]](https://github.com/ManageIQ/manageiq/pull/20355)
* Call `column_type` on parsed field to get the actual column type [[#20398]](https://github.com/ManageIQ/manageiq/pull/20398)
```

### output with `--display pr-label`

```text
bin/show_commit_history.rb --from jansa-1-rc1 --to jansa-1 --repo-set jansa --skip amazon_ssa_support --display pr-label
Git commit log between jansa-1-rc1 and jansa-1

=================================== manageiq ===================================

## Bug

* [AuthenticationMixin] Fix .authentication_status [[#20494]](https://github.com/ManageIQ/manageiq/pull/20494)
* enhance error handle for failing playbook clone [[#20232]](https://github.com/ManageIQ/manageiq/pull/20232)
* Updated vm_reconfigure_task in app/models to add disk Type information. [[#20081]](https://github.com/ManageIQ/manageiq/pull/20081)
* MiqSmartProxyWorker not running in Podified [[#20497]](https://github.com/ManageIQ/manageiq/pull/20497)
* Add supports_create_security_group virtual attribute [[#20482]](https://github.com/ManageIQ/manageiq/pull/20482)
* Allow services to set a queue_name for VM provisioning. [[#20468]](https://github.com/ManageIQ/manageiq/pull/20468)
* Improvement to action_check_compliance to avoid infinite loop. [[#20426]](https://github.com/ManageIQ/manageiq/pull/20426)
* Don't disconnect resource pools in refresh_new_target [[#20441]](https://github.com/ManageIQ/manageiq/pull/20441)
* Don't allow kafka exceptions to cause EmsEvent.add_queue to fail [[#20440]](https://github.com/ManageIQ/manageiq/pull/20440)
* Block attempt to create duplicate retire request  [[#20355]](https://github.com/ManageIQ/manageiq/pull/20355)
* Call `column_type` on parsed field to get the actual column type [[#20398]](https://github.com/ManageIQ/manageiq/pull/20398)

## Enhancement

* Update Gemfile.lock.release when tagging branch [[#20522]](https://github.com/ManageIQ/manageiq/pull/20522)
* Add ability to detect and cleanup failed deployments [[#20444]](https://github.com/ManageIQ/manageiq/pull/20444)
* add ids to the retirement log lines [[#20507]](https://github.com/ManageIQ/manageiq/pull/20507)

## Other

* [JANSA] Add jansa-1-rc2 Gemfile.lock as Gemfile.lock.release [[#20545]](https://github.com/ManageIQ/manageiq/pull/20545)
* Cleanup failed systemd services [[#20420]](https://github.com/ManageIQ/manageiq/pull/20420)
* log warning if creation of task to generate widget was skipped [[#20505]](https://github.com/ManageIQ/manageiq/pull/20505)
```

### `--help` with new options

```text
$ bin/show_commit_history.rb --help
Options:
  -f, --from=<s>        The commit log 'from' ref
  -t, --to=<s>          The commit log 'to' ref
  -d, --display=<s>     How to display the history. Valid values are: commit, pr-title, pr-label (default: commit)
  -k, --skip=<s+>       The repos to skip (default: manageiq-documentation)

Common Options:
  -s, --repo-set=<s>    The repo set to work with. (Default: master)
  -r, --repo=<s+>       Individual repo(s) to work with. Overrides --repo-set.
  -h, --help            Show this message
```