### PR TITLE
Add script to show a project's cards

### DIFF
--- a/bin/show_project_cards.rb
+++ b/bin/show_project_cards.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path("../lib", __dir__)
+
+require 'bundler/setup'
+require 'manageiq/release'
+require 'optimist'
+
+opts = Optimist.options do
+  opt :project_id, "The project ID",                :type => :integer, :required => true
+  opt :column,     "The column within the project", :type => :string,  :required => true
+
+  ManageIQ::Release.common_options(self, :only => :repo)
+end
+
+github = ManageIQ::Release.github
+repo = opts[:repo].first
+projects_headers = {:accept => "application/vnd.github.inertia-preview+json"}
+
+projects = github.send(repo.include?("/") ? :projects : :org_projects, repo, projects_headers)
+project  = projects.detect { |p| p.number == opts[:project_id] }
+Optimist.die :project_id, "not found" if project.nil?
+
+column = github.project_columns(project.id, projects_headers).detect { |c| c.name == opts[:column] }
+Optimist.die :column, "not found" if column.nil?
+
+cards = github.column_cards(column.id, projects_headers)
+issues = cards.map do |card|
+  org, repo, _issues, id = URI.parse(card.content_url).path.split("/").last(4)
+  github.issue("#{org}/#{repo}", id)
+end
+
+issues.each do |issue|
+  puts "* #{issue.title} [[##{issue.number}]](#{issue.html_url})"
+end


### PR DESCRIPTION
@chessbyte Please review.  This is what I used to get the overview of issues for the Jansa-1 release blog post.

Example of a run:

```markdown
$ bin/show_project_cards.rb --repo ManageIQ --project-id 13 --column Jansa
* [RFE] Support OpenID-Connect/OAuth2 [[#19867]](https://github.com/ManageIQ/manageiq/issues/19867)
* API Support for Compliance Policy Flow [[#782]](https://github.com/ManageIQ/manageiq-api/issues/782)
* API Support for Chargeback Flow [[#781]](https://github.com/ManageIQ/manageiq-api/issues/781)
* Direct link support for Chargeback UI elements [[#20162]](https://github.com/ManageIQ/manageiq/issues/20162)
* Switch to rpm based install for ManageIQ source code [[#411]](https://github.com/ManageIQ/manageiq-appliance-build/issues/411)
* httpd-init doesn't deploy on openshift when using cri-o runtime [[#361]](https://github.com/ManageIQ/manageiq-pods/issues/361)
* Decrease privileges for httpd pod [[#467]](https://github.com/ManageIQ/manageiq-pods/issues/467)
* [JANSA] [ActiveModel::UnknownAttributeError] unknown attribute 'skip_references' for MiqReport. [[#20106]](https://github.com/ManageIQ/manageiq/issues/20106)
* [Podification] Create Operator for Lifecycle Management [[#355]](https://github.com/ManageIQ/manageiq-pods/issues/355)
* [Appliance] Configure External Kafka Service [[#20001]](https://github.com/ManageIQ/manageiq/issues/20001)
* Add support for OpenShift 4.0 [[#139]](https://github.com/ManageIQ/manageiq-providers-openshift/issues/139)
* MiqAeNamespace should use ancestry instead of acts_as_tree [[#409]](https://github.com/ManageIQ/manageiq-automation_engine/issues/409)
* [Providers] Syndicate metrics over Kafka [[#19584]](https://github.com/ManageIQ/manageiq/issues/19584)
* [Providers] Syndicate events to Kafka [[#19583]](https://github.com/ManageIQ/manageiq/issues/19583)
* [Podification] Configure Kafka Service [[#20007]](https://github.com/ManageIQ/manageiq/issues/20007)
* Allow for productization of image builds [[#360]](https://github.com/ManageIQ/manageiq-pods/issues/360)
* [Podification] Container-based workers [[#352]](https://github.com/ManageIQ/manageiq-pods/issues/352)
* ManageIQ on k8s [[#312]](https://github.com/ManageIQ/manageiq-pods/issues/312)
* [Podification] Add an operations worker that doesn't need the VimBroker [[#468]](https://github.com/ManageIQ/manageiq-providers-vmware/pull/468)
* [Podification] Removal of the MiqVimBrokerWorker [[#484]](https://github.com/ManageIQ/manageiq-providers-vmware/issues/484)
* Enhance ManageIQ domain with RedHat content [[#630]](https://github.com/ManageIQ/manageiq-content/issues/630)
* [Podification] Make it work with Zones [[#353]](https://github.com/ManageIQ/manageiq-pods/issues/353)
* Support Rails 5.2 [[#20032]](https://github.com/ManageIQ/manageiq/issues/20032)
* Need account lockout policy [[#20043]](https://github.com/ManageIQ/manageiq/issues/20043)
* [Providers] Use k8s watches for targeted refresh [[#369]](https://github.com/ManageIQ/manageiq-providers-kubernetes/issues/369)
* [Providers] Use watches for openshift targeted refresh [[#171]](https://github.com/ManageIQ/manageiq-providers-openshift/issues/171)
* Support Pluggable Configuration Manager [[#19992]](https://github.com/ManageIQ/manageiq/issues/19992)
* [Automate Engine] Looking up objects in the database is expensive [[#410]](https://github.com/ManageIQ/manageiq-automation_engine/issues/410)
* Convert to Markdown [[#1432]](https://github.com/ManageIQ/manageiq-documentation/issues/1432)
```
