### PR TITLE
Add ability to close a milestone 

### DIFF
--- a/bin/update_milestone.rb
+++ b/bin/update_milestone.rb
@@ -7,12 +7,14 @@ require 'manageiq/release'
 require 'optimist'
 
 opts = Optimist.options do
-  opt :title,  "The new milestone title.",    :type => :string, :required => true
-  opt :due_on, "The new milestone due date.", :type => :string, :required => true
+  opt :title,  "The milestone title.",            :type => :string, :required => true
+  opt :due_on, "The due date.",                   :type => :string
+  opt :close,  "Whether to close the milestone.", :default => false
 
   ManageIQ::Release.common_options(self)
 end
-Optimist.die(:due_on, "must be a date format") unless ManageIQ::Release::UpdateMilestone.valid_date?(opts[:due_on])
+Optimist.die(:due_on, "is required") unless opts[:close]
+Optimist.die(:due_on, "must be a date format") if opts[:due_on] && !ManageIQ::Release::UpdateMilestone.valid_date?(opts[:due_on])
 
 ManageIQ::Release.each_repo(opts) do |repo|
   ManageIQ::Release::UpdateMilestone.new(repo, opts).run

--- a/bin/update_milestone.rb
+++ b/bin/update_milestone.rb
@@ -12,8 +12,8 @@ opts = Optimist.options do
 
   ManageIQ::Release.common_options(self)
 end
-Optimist.die(:due_on, "must be a date format") unless ManageIQ::Release::ReleaseMilestone.valid_date?(opts[:due_on])
+Optimist.die(:due_on, "must be a date format") unless ManageIQ::Release::UpdateMilestone.valid_date?(opts[:due_on])
 
 ManageIQ::Release.each_repo(opts) do |repo|
-  ManageIQ::Release::ReleaseMilestone.new(repo, opts).run
+  ManageIQ::Release::UpdateMilestone.new(repo, opts).run
 end

--- a/lib/manageiq/release.rb
+++ b/lib/manageiq/release.rb
@@ -15,11 +15,11 @@ require 'manageiq/release/git_mirror'
 require 'manageiq/release/internationalization'
 require 'manageiq/release/pull_request_blaster_outer'
 require 'manageiq/release/release_branch'
-require 'manageiq/release/release_milestone'
 require 'manageiq/release/release_tag'
 require 'manageiq/release/rename_labels'
 require 'manageiq/release/update_branch_protection'
 require 'manageiq/release/update_labels'
+require 'manageiq/release/update_milestone'
 require 'manageiq/release/update_repo_settings'
 
 module ManageIQ

--- a/lib/manageiq/release/update_milestone.rb
+++ b/lib/manageiq/release/update_milestone.rb
@@ -2,7 +2,7 @@ require "active_support/core_ext/time"
 
 module ManageIQ
   module Release
-    class ReleaseMilestone
+    class UpdateMilestone
       def self.valid_date?(date)
         !!parse_date(date)
       end


### PR DESCRIPTION
Additionally this PRs renames release_milestone to update_milestone.  I chose to rename the existing, and then add the close functionality to the existing command.  I think "update" is more accurate as it can be used for both new milestones and updates (and now closing).  This is also useful when new repos are added, we can then just blast out an update to all repos, or if we need to update the due date on all milestones.   

@chessbyte Please review.