### PR TITLE
Get Travis status from travis-ci.com instead of travis-ci.org

### DIFF
--- a/bin/show_travis_status.rb
+++ b/bin/show_travis_status.rb
@@ -6,6 +6,7 @@ require 'bundler/setup'
 require 'manageiq/release'
 require 'more_core_extensions/core_ext/array/tableize'
 require 'travis'
+require 'travis/pro/auto_login'
 require 'optimist'
 
 opts = Optimist.options do
@@ -18,7 +19,7 @@ opts[:repo_set] = opts[:ref].split("-").first unless opts[:repo] || opts[:repo_s
 travis_repos = ManageIQ::Release.repos_for(opts).collect do |repo|
   next if repo.options.has_real_releases
 
-  repo = Travis::Repository.find(repo.github_repo)
+  repo = Travis::Pro::Repository.find(repo.github_repo)
   begin
     last_build = repo.last_on_branch(opts[:ref])
   rescue Travis::Client::NotFound


### PR DESCRIPTION
Getting build status from travis-ci.com requires authentication.

I didn't add an alternative way when auto login fails. I'm not quite sure how auto login works, as it works for me even if I remove travis config file with token, etc.  I can look for a specific environment variable and use that as a token if a fallback way is needed.