### PR TITLE
Add a config yml with groups of repos

### DIFF
--- a/config/repos.sets.yml
+++ b/config/repos.sets.yml
@@ -1,0 +1,38 @@
+---
+core: &core
+  manageiq:
+  manageiq-api:
+  manageiq-ui-classic:
+  manageiq-automation_engine:
+  manageiq-consumption:
+  manageiq-content:
+  manageiq-decorators:
+  manageiq-gems-pending:
+  manageiq-graphql:
+  manageiq-schema:
+  manageiq-ui-service:
+  manageiq-v2v:
+providers: &providers
+  manageiq-providers-amazon:
+  manageiq-providers-ansible_tower:
+  manageiq-providers-autosde:
+  manageiq-providers-azure:
+  manageiq-providers-azure_stack:
+  manageiq-providers-foreman:
+  manageiq-providers-google:
+  manageiq-providers-ibm_cloud:
+  manageiq-providers-ibm_terraform:
+  manageiq-providers-kubernetes:
+  manageiq-providers-kubevirt:
+  manageiq-providers-lenovo:
+  manageiq-providers-nsxt:
+  manageiq-providers-nuage:
+  manageiq-providers-openshift:
+  manageiq-providers-openstack:
+  manageiq-providers-ovirt:
+  manageiq-providers-redfish:
+  manageiq-providers-scvmm:
+  manageiq-providers-vmware:
+all:
+  <<: *core
+  <<: *providers


### PR DESCRIPTION
Add a config file which groups the various repos into buckets which can be used to run operations on e.g. all providers or just core

One use-case is `@miq-bot cross_repo_tests` https://github.com/ManageIQ/miq_bot/pull/526