### PR TITLE
Add has_real_releases to kasparov ui-components

### DIFF
--- a/config/repos.yml
+++ b/config/repos.yml
@@ -119,6 +119,7 @@ kasparov:
   manageiq-ui-service:
   manageiq-v2v:
   ui-components:
+    has_real_releases: true
 jansa:
   amazon_ssa_support:
   container-amazon-smartstate:


### PR DESCRIPTION
We don't tag ui-components, so adding `has_real_releases` for kasparov.