### PR TITLE
Add an option to skip tagging

### DIFF
--- a/bin/destroy_tag.rb
+++ b/bin/destroy_tag.rb
@@ -16,6 +16,8 @@ opts[:repo_set] = opts[:tag].split("-").first unless opts[:repo] || opts[:repo_s
 post_review = StringIO.new
 
 ManageIQ::Release.each_repo(opts) do |repo|
+  next if repo.options.has_real_releases || repo.options.skip_tag
+
   destroy_tag = ManageIQ::Release::DestroyTag.new(repo, opts)
   destroy_tag.run
   post_review.puts(destroy_tag.post_review)

--- a/bin/release_tag.rb
+++ b/bin/release_tag.rb
@@ -26,7 +26,7 @@ repos = repos.partition { |r| r.github_repo != "ManageIQ/manageiq" }.flatten
 
 repos.each do |repo|
   next if Array(opts[:skip]).include?(repo.name)
-  next if repo.options.has_real_releases
+  next if repo.options.has_real_releases || repo.options.skip_tag
 
   release_tag = ManageIQ::Release::ReleaseTag.new(repo, opts)
 

--- a/config/repos.yml
+++ b/config/repos.yml
@@ -1,6 +1,7 @@
 master:
   amazon_ssa_support:
   container-amazon-smartstate:
+    skip_tag: true
   container-httpd:
     has_real_releases: true
   container-memcached:
@@ -58,10 +59,11 @@ master:
   manageiq-ui-service:
   manageiq-v2v:
   ui-components:
+    skip_tag: true
 kasparov:
   amazon_ssa_support:
   container-amazon-smartstate:
-    has_real_releases: true
+    skip_tag: true
   container-httpd:
     has_real_releases: true
   container-memcached:
@@ -119,10 +121,11 @@ kasparov:
   manageiq-ui-service:
   manageiq-v2v:
   ui-components:
+    skip_tag: true
 jansa:
   amazon_ssa_support:
   container-amazon-smartstate:
-    has_real_releases: true
+    skip_tag: true
   container-httpd:
     has_real_releases: true
   container-memcached:
@@ -176,11 +179,11 @@ jansa:
   manageiq-ui-service:
   manageiq-v2v:
   ui-components:
-    has_real_releases: true
+    skip_tag: true
 ivanchuk:
   amazon_ssa_support:
   container-amazon-smartstate:
-    has_real_releases: true
+    skip_tag: true
   container-httpd:
     has_real_releases: true
   container-memcached:
@@ -234,11 +237,11 @@ ivanchuk:
   manageiq-ui-service:
   manageiq-v2v:
   ui-components:
-    has_real_releases: true
+    skip_tag: true
 hammer:
   amazon_ssa_support:
   container-amazon-smartstate:
-    has_real_releases: true
+    skip_tag: true
   container-httpd:
     has_real_releases: true
   container-memcached:
@@ -290,7 +293,7 @@ hammer:
   manageiq-ui-service:
   manageiq-v2v:
   ui-components:
-    has_real_releases: true
+    skip_tag: true
 gaprindashvili:
   amazon_ssa_support:
   container-httpd:
@@ -340,7 +343,7 @@ gaprindashvili:
   manageiq-ui-service:
   manageiq-v2v:
   ui-components:
-    has_real_releases: true
+    skip_tag: true
 fine:
   manageiq:
     has_rake_release: true


### PR DESCRIPTION
We have 2 repos (container-amazon-smartstate and ui-components) that we'd like to create branches, etc. but don't want to tag.

Adding an option to just skip tagging, so we don't have to add `has_real_releases` for non-master branches.