### PR TITLE
Add debugging and error raising to git_clone

### DIFF
--- a/lib/manageiq/release/repo.rb
+++ b/lib/manageiq/release/repo.rb
@@ -102,7 +102,9 @@ module ManageIQ
 
       def git_clone
         clone_source = options.clone_source || "git@github.com:#{github_repo}.git"
-        exit($CHILD_STATUS.exitstatus) unless system("git clone #{clone_source} #{path}")
+        args = ["clone", clone_source, path]
+        puts "+ git #{args.join(" ")}" if ENV["GIT_DEBUG"]
+        raise MiniGit::GitError.new(args, $?) unless system("git #{args.join(" ")}")
       end
     end
   end


### PR DESCRIPTION
@chessbyte Please review.

When I was working on a new script that needed to clone repos from private sources I ran into a few issues, and it was helpful to have proper debugging and consistent errors on the git_clone.