### PR TITLE
Add a summary of repos to show_commit_history

### DIFF
--- a/bin/show_commit_history.rb
+++ b/bin/show_commit_history.rb
@@ -6,15 +6,21 @@ require 'bundler/setup'
 require 'manageiq/release'
 require 'optimist'
 
+DISPLAY_FORMATS = %w[commit pr-title pr-label]
+
 opts = Optimist.options do
-  opt :from, "The commit log 'from' ref", :type => :string,  :required => true
-  opt :to,   "The commit log 'to' ref" ,  :type => :string,  :required => true
-  opt :skip, "The repos to skip",         :type => :strings, :default => ["manageiq-documentation"]
+  opt :from,    "The commit log 'from' ref", :type => :string,  :required => true
+  opt :to,      "The commit log 'to' ref" ,  :type => :string,  :required => true
+  opt :display, "How to display the history. Valid values are: #{DISPLAY_FORMATS.join(", ")}", :default => "commit"
+
+  opt :skip,   "The repos to skip", :default => ["manageiq-documentation"]
 
   ManageIQ::Release.common_options(self, :except => :dry_run)
 end
+Optimist.die :display, "must be one of: #{DISPLAY_FORMATS.join(", ")}" unless DISPLAY_FORMATS.include?(opts[:display])
 
 range = "#{opts[:from]}..#{opts[:to]}"
+github = ManageIQ::Release.github
 
 puts "Git commit log between #{opts[:from]} and #{opts[:to]}\n\n"
 
@@ -24,6 +30,38 @@ ManageIQ::Release.repos_for(opts).each do |repo|
 
   puts ManageIQ::Release.header(repo.name)
   repo.fetch(output: false)
-  repo.git.log({:oneline => true, :decorate => true, :reverse => true}, range)
-  puts "\n\n"
+
+  case opts[:display]
+  when "pr-label", "pr-title"
+    pr_label_display = opts[:display] == "pr-label"
+
+    results = {}
+    if pr_label_display
+      results["bug"] = []
+      results["enhancement"] = []
+    end
+    results["other"] = []
+
+    log = repo.git.capturing.log({:oneline => true}, range)
+    log.lines.each do |line|
+      next unless (match = line.match(/Merge pull request #(\d+)\b/))
+
+      pr = github.pull_request(repo.github_repo, match[1])
+      label = pr.labels.detect { |l| results.key?(l.name) }&.name || "other"
+      results[label] << pr
+    end
+
+    results.each do |label, prs|
+      next if prs.blank?
+
+      puts "\n## #{label.titleize}\n\n" if pr_label_display
+      prs.each do |pr|
+        puts "* #{pr.title} [[##{pr.number}]](#{pr.html_url})"
+      end
+    end
+  when "commit"
+    repo.git.git([{:no_pager => true}, :log, {:oneline => true, :decorate => true, :graph => true}], range)
+  end
+
+  puts
 end


### PR DESCRIPTION
Built on #159 

Example:

```

Here are the changes per affected repository in GitHub:
- [manageiq](https://github.com/ManageIQ/manageiq/compare/jansa-1...jansa-2)
- [manageiq-api](https://github.com/ManageIQ/manageiq-api/compare/jansa-1...jansa-2)
- [manageiq-appliance](https://github.com/ManageIQ/manageiq-appliance/compare/jansa-1...jansa-2)
- [manageiq-appliance-build](https://github.com/ManageIQ/manageiq-appliance-build/compare/jansa-1...jansa-2)
- [manageiq-content](https://github.com/ManageIQ/manageiq-content/compare/jansa-1...jansa-2)
- [manageiq-pods](https://github.com/ManageIQ/manageiq-pods/compare/jansa-1...jansa-2)
- [manageiq-providers-amazon](https://github.com/ManageIQ/manageiq-providers-amazon/compare/jansa-1...jansa-2)
- [manageiq-providers-ovirt](https://github.com/ManageIQ/manageiq-providers-ovirt/compare/jansa-1...jansa-2)
- [manageiq-providers-vmware](https://github.com/ManageIQ/manageiq-providers-vmware/compare/jansa-1...jansa-2)
- [manageiq-rpm_build](https://github.com/ManageIQ/manageiq-rpm_build/compare/jansa-1...jansa-2)
- [manageiq-ui-classic](https://github.com/ManageIQ/manageiq-ui-classic/compare/jansa-1...jansa-2)
- [manageiq-ui-service](https://github.com/ManageIQ/manageiq-ui-service/compare/jansa-1...jansa-2)
- [manageiq-v2v](https://github.com/ManageIQ/manageiq-v2v/compare/jansa-1...jansa-2)
```

Note that this is the format we use for the blog posts for releases, so with this, this script effectively becomes a blog post generator of sorts