### PR TITLE
Add tool to update Travis settings

### DIFF
--- a/bin/new_plugin_repo.rb
+++ b/bin/new_plugin_repo.rb
@@ -23,6 +23,8 @@ puts "\n** Updating Branch Protection"
 ManageIQ::Release::UpdateBranchProtection.new(repo.github_repo, opts.merge(:branch => "master")).run
 puts "\n** Updating Labels"
 ManageIQ::Release::UpdateLabels.new(repo.github_repo, opts).run
+puts "\n** Updating Travis Settings"
+ManageIQ::Release::UpdateTravisSettings.new(repo.github_repo, opts.merge(:branch => "master")).run
 
 puts "\n** Preparing Pull Request"
 ManageIQ::Release::PullRequestBlasterOuter.new(repo, opts.merge(

--- a/bin/update_travis_settings.rb
+++ b/bin/update_travis_settings.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path("../lib", __dir__)
+
+require 'bundler/setup'
+require 'manageiq/release'
+require 'optimist'
+
+opts = Optimist.options do
+  ManageIQ::Release.common_options(self)
+end
+
+ManageIQ::Release.each_repo(opts) do |repo|
+  ManageIQ::Release::UpdateTravisSettings.new(repo.github_repo, opts).run
+end

--- a/lib/manageiq/release.rb
+++ b/lib/manageiq/release.rb
@@ -21,6 +21,7 @@ require 'manageiq/release/update_branch_protection'
 require 'manageiq/release/update_labels'
 require 'manageiq/release/update_milestone'
 require 'manageiq/release/update_repo_settings'
+require 'manageiq/release/update_travis_settings'
 
 module ManageIQ
   module Release
@@ -121,6 +122,14 @@ module ManageIQ
       @github_api_token = token
     end
 
+    def self.travis_api_token
+      @travis_api_token ||= ENV["TRAVIS_API_TOKEN"]
+    end
+
+    def self.travis_api_token=(token)
+      @travis_api_token = token
+    end
+
     #
     # Services
     #
@@ -142,6 +151,18 @@ module ManageIQ
         .list_repositories(org, :type => "sources")
         .reject { |r| r.fork? || r.archived? }
         .map { |r| "#{org}/#{r.name}" }
+    end
+
+    def self.travis
+      @travis ||= begin
+        raise "Missing Travis API Token" if travis_api_token.nil?
+
+        require 'travis/client'
+        ::Travis::Client.new(
+          :uri           => ::Travis::Client::COM_URI,
+          :access_token  => travis_api_token
+        )
+      end
     end
   end
 end

--- a/lib/manageiq/release/update_travis_settings.rb
+++ b/lib/manageiq/release/update_travis_settings.rb
@@ -1,0 +1,37 @@
+module ManageIQ
+  module Release
+    class UpdateTravisSettings
+      attr_reader :repo, :dry_run
+
+      def initialize(repo, dry_run: false, **_)
+        @repo    = repo
+        @dry_run = dry_run
+      end
+
+      def run
+        edit_travis
+      end
+
+      private
+
+      def edit_travis
+        puts "Editing #{repo}"
+
+        settings = {
+          :auto_cancel_pull_requests => true,
+          :auto_cancel_pushes        => true
+        }
+
+        if dry_run
+          puts "** dry-run: travis.settings.update_attributes(#{settings.inspect[1..-2]})"
+        else
+          travis.settings.update_attributes(settings)
+        end
+      end
+
+      def travis
+        @travis ||= ManageIQ::Release.travis.repo(repo)
+      end
+    end
+  end
+end


### PR DESCRIPTION
@simaishi @chessbyte Please review.

I noticed a bunch of our repos didn't have "auto cancel" set, which can save a lot of unnecessary travis runs.  This script will allow us to blast out those settings changes, and perhaps other Travis things in the future.