### PR TITLE
Add workaround for labels with '?'

### DIFF
--- a/lib/manageiq/release/update_labels.rb
+++ b/lib/manageiq/release/update_labels.rb
@@ -45,6 +45,10 @@ module ManageIQ
       def update(label, color)
         puts "Updating #{label.inspect} to #{color.inspect}"
 
+        # Temporary HACK until https://github.com/octokit/octokit.rb/pull/1297 is merged and released
+        require "erb"
+        label = ERB::Util.url_encode(label)
+
         if dry_run
           puts "** dry-run: github.update_label(#{repo.inspect}, #{label.inspect}, :color => #{color.inspect})"
         else


### PR DESCRIPTION
@chessbyte Please review.

Without this PR, I can't update the label colors of labels like `kasparov/yes?`.  See also https://github.com/octokit/octokit.rb/pull/1297