### PR TITLE
Rename semver labels

### DIFF
--- a/config/labels.yml
+++ b/config/labels.yml
@@ -37,8 +37,8 @@ common: &common
   wontfix: "eeeeee"
 
 semver: &semver
-  "needs major version": "6a92bc"
-  "needs minor version": "6a92bc"
+  "semver/major": "6a92bc"
+  "semver/minor": "6a92bc"
 
 provider_plugin: &provider_plugin
   events: "5319e7"


### PR DESCRIPTION
The existing labels are hard to find, as you are usually looking for
the word "semver". The new labels will facilitate that.

@chessbyte Please review.