### PR TITLE
Do not remove the yes label when finding a conflict

### DIFF
--- a/lib/manageiq/release/backport_prs.rb
+++ b/lib/manageiq/release/backport_prs.rb
@@ -80,7 +80,6 @@ module ManageIQ
             in order to resolve this.
           BODY
 
-          remove_label(pr_number, "#{branch}/yes")
           add_label(pr_number, "#{branch}/conflict")
 
           false


### PR DESCRIPTION
@chessbyte Please review.  This is minor, but it was a nuance of how the labeling worked previously that I misunderstood.  The issue is that when you list the PRs eligible for backport with `/yes`, these would be ignored.  While we check for conflicts anyway during the actual backport, the list command acts weird without this.