### PR TITLE
Fix incorrect ordering of fetch and checkout

### DIFF
--- a/lib/manageiq/release/backport_prs.rb
+++ b/lib/manageiq/release/backport_prs.rb
@@ -27,8 +27,8 @@ module ManageIQ
       end
 
       def run
-        repo.checkout(branch)
         repo.fetch
+        repo.checkout(branch)
         backport_prs
       end
 


### PR DESCRIPTION
@chessbyte Please review.

The effect of this issue is that the cherry-picker creates a pick on too early of a commit, and gets a rejection error, which makes sense, since we didn't fetch the latest before switching.