### PR TITLE
Fix issue where modifying badges in place modified the original badges

### DIFF
--- a/lib/manageiq/release/readme_badges.rb
+++ b/lib/manageiq/release/readme_badges.rb
@@ -1,3 +1,5 @@
+require "active_support/core_ext/object/deep_dup"
+
 module ManageIQ
   module Release
     class ReadmeBadges
@@ -41,7 +43,7 @@ module ManageIQ
       def reload_badges(lines)
         lines ||= content.lines
         @badges = extract_badges(lines)
-        @original_badges = @badges.dup
+        @original_badges = @badges.deep_dup
         @original_badge_indexes = @badges.map { |b| b["index"] }
       end
 


### PR DESCRIPTION
@agrare Please review.

The issue is evident when we run the new_plugin_repo script, which modifies the badges like the codeclimate badge, but since the script uses Hash#update, it also modifies the original.  When we compare for a dirty check, it looks like nothing changed and the readme is not updated.