### PR TITLE
Add scripts to list org members and make them alumni

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,6 @@ gem "minigit",              :require => false
 gem "more_core_extensions", :require => false
 gem "octokit", ">=4.7.0",   :require => false
 gem "optimist",             :require => false
+gem "progressbar",          :require => false
 gem "rest-client",          :require => false
 gem "travis",               :require => false

--- a/bin/make_alumni.rb
+++ b/bin/make_alumni.rb
@@ -1,0 +1,95 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path("../lib", __dir__)
+
+require 'bundler/setup'
+require 'manageiq/release'
+require 'optimist'
+
+opts = Optimist.options do
+  opt :users, "The users to make alumni.",     :type => :strings, :required => true
+  opt :org,   "The org in which user belongs", :default => "ManageIQ"
+
+  ManageIQ::Release.common_options(self, :only => :dry_run)
+end
+
+class ManageIQ::Release::MakeAlumni
+  attr_reader :org, :dry_run
+
+  def initialize(org:, dry_run:, **_)
+    @org     = org
+    @dry_run = dry_run
+  end
+
+  def run(user)
+    progress = ManageIQ::Release.progress_bar(teams.size + repos.size)
+
+    add_team_membership("alumni", user)
+    progress.increment
+
+    non_alumni_teams = teams - ["alumni"]
+    non_alumni_teams.each do |team|
+      remove_team_membership(team, user)
+      progress.increment
+    end
+
+    repos.each do |repo|
+      remove_collaborator(repo, user)
+      progress.increment
+    end
+
+    progress.finish
+  end
+
+  private
+
+  def team_ids
+    @team_ids ||= github.org_teams(org).map { |t| [t.slug, t.id] }.sort.to_h
+  end
+
+  def teams
+    @teams ||= team_ids.keys
+  end
+
+  def repos
+    @repos ||= github.org_repos(org).reject(&:archived?).map(&:full_name).sort
+  end
+
+  def add_team_membership(team, user)
+    team_id = team_ids[team]
+
+    if dry_run
+      puts "** dry-run: github.add_team_membership(#{team_id.inspect}, #{user.inspect})"
+    else
+      github.add_team_membership(team_id, user)
+    end
+  end
+
+  def remove_team_membership(team, user)
+    team_id = team_ids[team]
+
+    if dry_run
+      puts "** dry-run: github.remove_team_membership(#{team_id.inspect}, #{user.inspect})"
+    else
+      github.remove_team_membership(team_id, user)
+    end
+  end
+
+  def remove_collaborator(repo, user)
+    if dry_run
+      puts "** dry-run: github.remove_collaborator(#{repo.inspect}, #{user.inspect})"
+    else
+      github.remove_collaborator(repo, user)
+    end
+  end
+
+  def github
+    ManageIQ::Release.github
+  end
+end
+
+make_alumni = ManageIQ::Release::MakeAlumni.new(opts)
+opts[:users].each do |user|
+  puts ManageIQ::Release.header(user)
+  make_alumni.run(user)
+end

--- a/bin/show_org_members.rb
+++ b/bin/show_org_members.rb
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path("../lib", __dir__)
+
+require 'bundler/setup'
+require 'manageiq/release'
+require 'optimist'
+
+opts = Optimist.options do
+  opt :org,    "The org to list the users for",    :default => "ManageIQ"
+  opt :team,   "Show members of a specific team",  :type => :string
+  opt :alumni, "Whether or not to include alumni", :default => false
+end
+
+def github
+  ManageIQ::Release.github
+end
+
+def org_members(org:, **_)
+  github.org_members(org).map(&:login).sort_by(&:downcase)
+end
+
+def team_members(org:, team:, **_)
+  team_id = github.org_teams(org).detect { |t| t.slug == team }.id
+  github.team_members(team_id).map(&:login).sort_by(&:downcase)
+end
+
+members  = opts[:team] ? team_members(opts) : org_members(opts)
+members -= team_members(opts.merge(team: "alumni")) unless opts[:alumni]
+
+puts members

--- a/lib/manageiq/release.rb
+++ b/lib/manageiq/release.rb
@@ -92,8 +92,9 @@ module ManageIQ
     # Logging helpers
     #
 
-    HEADER = ("=" * 80).freeze
-    SEPARATOR = ("*" * 80).freeze
+    HEADER_SIZE = 80
+    HEADER      = ("=" * HEADER_SIZE).freeze
+    SEPARATOR   = ("*" * HEADER_SIZE).freeze
 
     def self.header(title)
       title = " #{title} "
@@ -103,6 +104,15 @@ module ManageIQ
 
     def self.separator
       SEPARATOR
+    end
+
+    def self.progress_bar(total = 100)
+      require "progressbar"
+      ProgressBar.create(
+        :format => "%j%% |%B| %E",
+        :length => HEADER_SIZE,
+        :total  => total
+      )
     end
 
     #


### PR DESCRIPTION
@chessbyte Please review.

```sh
bin/show_org_members.rb                            # List members of the org
bin/show_org_members.rb --alumni                   # List members of the org including alumni
bin/show_org_members.rb --team some-team           # List member of a specific org team
bin/show_org_members.rb --team some-team --alumni  # List members of a specific org team including alumni

bin/make_alumni.rb --users some_user               # Make a single user an alumni
bin/make_alumni.rb --users some_user another_user  # Make multiple users alumni

# Make all users in a specific org team into alumni 😱
bin/show_org_members.rb --team some-team --alumni | xargs bin/make_alumni.rb --users  
```
