### PR TITLE
Add simple tool that exposes the GitHub rate limit

### DIFF
--- a/bin/github_rate_limit.rb
+++ b/bin/github_rate_limit.rb
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path("../lib", __dir__)
+
+require 'bundler/setup'
+require 'manageiq/release'
+
+puts [ManageIQ::Release.github.rate_limit.to_h].tableize


### PR DESCRIPTION
This tool is pretty useful, especially while creating other scripts

@bdunne  Please review.