### PR TITLE
Add ability to run branch specific release tasks on new branches

### DIFF
--- a/bin/release_branch.rb
+++ b/bin/release_branch.rb
@@ -8,9 +8,10 @@ require 'optimist'
 
 opts = Optimist.options do
   opt :branch,        "The new branch name.",                                   :type => :string, :required => true
+  opt :next_branch,   "The next branch name.",                                  :type => :string, :required => true
   opt :source_branch, "The source branch from which to create the new branch.", :default => "master"
 
-  ManageIQ::Release.common_options(self, :except => :dry_run, :repo_set_default => nil) # TODO: Implement dry_run
+  ManageIQ::Release.common_options(self, :repo_set_default => nil)
 end
 opts[:repo_set] = opts[:branch] unless opts[:repo] || opts[:repo_set]
 
@@ -29,7 +30,9 @@ ManageIQ::Release.repos_for(opts).each do |repo|
   review.puts ManageIQ::Release.header(repo.name)
   review.puts release_branch.review
   review.puts
-  post_review.puts release_branch.post_review
+
+  post_msg = release_branch.post_review
+  post_review.puts post_msg if post_msg
 end
 
 puts

--- a/config/repos.yml
+++ b/config/repos.yml
@@ -1,6 +1,8 @@
 master:
   amazon_ssa_support:
+    has_rake_release_new_branch: true
   container-amazon-smartstate:
+    has_rake_release_new_branch: true
     skip_tag: true
   container-httpd:
     has_real_releases: true
@@ -16,9 +18,13 @@ master:
     has_real_releases: true
   manageiq:
     has_rake_release: true
+    has_rake_release_new_branch: true
+    has_rake_release_new_branch_master: true
   manageiq-api:
   manageiq-appliance:
   manageiq-appliance-build:
+    has_rake_release_new_branch: true
+    has_rake_release_new_branch_master: true
   manageiq-appliance_console:
     has_real_releases: true
   manageiq-automation_engine:
@@ -27,10 +33,15 @@ master:
     has_rake_release: true
   manageiq-decorators:
   manageiq-documentation:
+    has_rake_release_new_branch: true
+    has_rake_release_new_branch_master: true
   manageiq-gems-pending:
   manageiq-graphql:
   manageiq-pods:
+    has_rake_release_new_branch: true
+    has_rake_release_new_branch_master: true
   manageiq-providers-amazon:
+    has_rake_release_new_branch: true
   manageiq-providers-ansible_tower:
   manageiq-providers-autosde:
   manageiq-providers-azure:
@@ -54,6 +65,8 @@ master:
   manageiq-providers-vmware:
   manageiq-rpm_build:
     has_rake_release: true
+    has_rake_release_new_branch: true
+    has_rake_release_new_branch_master: true
   manageiq-schema:
   manageiq-smartstate:
     has_real_releases: true
@@ -64,7 +77,9 @@ master:
     skip_tag: true
 morphy:
   amazon_ssa_support:
+    has_rake_release_new_branch: true
   container-amazon-smartstate:
+    has_rake_release_new_branch: true
     skip_tag: true
   container-httpd:
     has_real_releases: true
@@ -80,9 +95,13 @@ morphy:
     has_real_releases: true
   manageiq:
     has_rake_release: true
+    has_rake_release_new_branch: true
+    has_rake_release_new_branch_master: true
   manageiq-api:
   manageiq-appliance:
   manageiq-appliance-build:
+    has_rake_release_new_branch: true
+    has_rake_release_new_branch_master: true
   manageiq-appliance_console:
     has_real_releases: true
   manageiq-automation_engine:
@@ -91,10 +110,15 @@ morphy:
     has_rake_release: true
   manageiq-decorators:
   manageiq-documentation:
+    has_rake_release_new_branch: true
+    has_rake_release_new_branch_master: true
   manageiq-gems-pending:
   manageiq-graphql:
   manageiq-pods:
+    has_rake_release_new_branch: true
+    has_rake_release_new_branch_master: true
   manageiq-providers-amazon:
+    has_rake_release_new_branch: true
   manageiq-providers-ansible_tower:
   manageiq-providers-autosde:
   manageiq-providers-azure:
@@ -116,6 +140,8 @@ morphy:
   manageiq-providers-vmware:
   manageiq-rpm_build:
     has_rake_release: true
+    has_rake_release_new_branch: true
+    has_rake_release_new_branch_master: true
   manageiq-schema:
   manageiq-smartstate:
     has_real_releases: true

--- a/lib/manageiq/release.rb
+++ b/lib/manageiq/release.rb
@@ -93,17 +93,15 @@ module ManageIQ
     #
 
     HEADER_SIZE = 80
-    HEADER      = ("=" * HEADER_SIZE).freeze
-    SEPARATOR   = ("*" * HEADER_SIZE).freeze
 
     def self.header(title)
       title = " #{title} "
-      start = (HEADER.length / 2) - (title.length / 2)
-      HEADER.dup.tap { |h| h[start, title.length] = title }
+      start = (HEADER_SIZE / 2) - (title.length / 2)
+      separator("=").tap { |h| h[start, title.length] = title }
     end
 
-    def self.separator
-      SEPARATOR
+    def self.separator(char = "*")
+      char * HEADER_SIZE
     end
 
     def self.progress_bar(total = 100)

--- a/lib/manageiq/release/release_branch.rb
+++ b/lib/manageiq/release/release_branch.rb
@@ -1,12 +1,17 @@
 module ManageIQ
   module Release
     class ReleaseBranch
-      attr_reader :repo, :branch, :source_branch
+      attr_reader :repo, :branch, :next_branch, :source_branch, :dry_run
 
-      def initialize(repo, branch:, source_branch: "master", **_)
+      def initialize(repo, branch:, next_branch:, source_branch: "master", dry_run:, **_)
         @repo          = repo
         @branch        = branch
+        @next_branch   = next_branch
         @source_branch = source_branch
+        @dry_run       = dry_run
+
+        @branch_changes = false
+        @master_changes = false
       end
 
       def run
@@ -14,26 +19,61 @@ module ManageIQ
         repo.checkout(branch, "origin/#{source_branch}")
 
         repo.chdir do
-          changes = edit_bin_setup
-          changes = edit_readme || changes
+          @branch_changes = apply_common_branch_changes
+          @branch_changes = apply_branch_changes || @branch_changes
 
-          if changes
-            repo.git.add(".")
-            repo.git.commit("-m", "Changes for #{branch} branch release.")
-          end
+          @master_changes = apply_master_changes
         end
       end
 
       def review
-        repo.git.capturing.log("-1", "-p", :graph => true, :pretty => "format:\%h -\%d \%s (\%cr) <\%an>")
+        branch_diff = repo.git.capturing.log("-2", "-p", branch, :graph => true, :pretty => "format:\%h -\%d \%s (\%cr) <\%an>").chomp if @branch_changes
+        master_diff = repo.git.capturing.log("-1", "-p", "master", :graph => true, :pretty => "format:\%h -\%d \%s (\%cr) <\%an>").chomp if @master_changes
+
+        [branch_diff, master_diff].compact.join("\n\n#{ManageIQ::Release.separator("-")}\n\n")
       end
 
       def post_review
         # TODO: Automate this with some questions at branch time
-        "pushd #{repo.path}; OVERRIDE=true git push origin #{branch}; popd"
+        branches = []
+        branches << branch   if @branch_changes
+        branches << "master" if @master_changes
+        return if branches.empty?
+
+        "pushd #{repo.path}; OVERRIDE=true git push origin #{branches.join(" ")}; popd"
       end
 
       private
+
+      def apply_common_branch_changes
+        changes = edit_bin_setup
+        changes = edit_readme || changes
+
+        if changes
+          repo.git.add(".")
+          repo.git.commit("-m", "Changes for new branch #{branch}.")
+        end
+
+        changes
+      end
+
+      def apply_branch_changes
+        return unless repo.options.has_rake_release_new_branch
+
+        rake_release("new_branch")
+
+        true
+      end
+
+      def apply_master_changes
+        return unless repo.options.has_rake_release_new_branch_master
+
+        repo.checkout("master", "origin/master")
+        rake_release("new_branch_master")
+        repo.git.checkout(branch)
+
+        true
+      end
 
       def edit_bin_setup
         editing_file("bin/setup") do |contents|
@@ -64,6 +104,28 @@ module ManageIQ
         else
           false
         end
+      end
+
+      def rake_release(task)
+        rake("release:#{task}", {"RELEASE_BRANCH" => branch, "RELEASE_BRANCH_NEXT" => next_branch})
+      end
+
+      def rake(task, env)
+        if dry_run
+          env_str = env.map { |k, v| "#{k}=#{v}" }.join(" ")
+
+          puts "** dry-run: bundle check || bundle update"
+          puts "** dry-run: #{env_str} bundle exec rake #{task}"
+        else
+          Bundler.with_clean_env do
+            system!("bundle check || bundle update", :chdir => repo.path)
+            system!(env, "bundle exec rake #{task}", :chdir => repo.path)
+          end
+        end
+      end
+
+      def system!(*args)
+        exit($?.exitstatus) unless system(*args)
       end
     end
   end


### PR DESCRIPTION
@bdunne Please review.

This was verified with the existing morphy branch.

This should also remove the entirety of bullet 4 in https://github.com/ManageIQ/manageiq-release/pull/188 (See https://github.com/ManageIQ/manageiq-release/pull/188/files#diff-a00b15d22aec52736ccd73f08c91df2547d2a7f0c36937a78c4bb5d0995e44efR32)