### PR TITLE
Change backporting to backport until we hit a conflict

### DIFF
--- a/bin/backport_prs.rb
+++ b/bin/backport_prs.rb
@@ -48,27 +48,10 @@ def list_prs(branch, repos, opts)
 end
 
 def backport_prs(branch, repos, opts)
-  conflicts = ManageIQ::Release::BackportPrs.search(repos.keys, "#{branch}/conflict")
-  backports = ManageIQ::Release::BackportPrs.search(repos.keys, "#{branch}/yes")
-  all_repos = (conflicts.keys | backports.keys).sort
-
-  all_repos.each do |github_repo|
+  backports = ManageIQ::Release::BackportPrs.search(repos.keys, "#{branch}/yes").sort!
+  backports.each do |github_repo, prs|
     puts ManageIQ::Release.header(github_repo)
-
-    if conflicts.include?(github_repo)
-      ManageIQ::Release::StringFormatting.enable
-      puts "A conflict label still exists on the following PRs.  Skipping.".red
-      puts
-      conflicts[github_repo].each do |pr|
-        puts "** #{github_repo}##{pr.number}".red
-      end
-      puts
-      next
-    end
-
-    repo = repos[github_repo]
-    prs  = backports[github_repo]
-    ManageIQ::Release::BackportPrs.new(repo, opts.merge(:prs => prs)).run
+    ManageIQ::Release::BackportPrs.new(repos[github_repo], opts.merge(:prs => prs)).run
   end
 end
 

--- a/lib/manageiq/release/backport_prs.rb
+++ b/lib/manageiq/release/backport_prs.rb
@@ -37,17 +37,17 @@ module ManageIQ
       def backport_prs
         prs.each do |pr|
           puts
-          puts "** #{github_repo}##{pr.number}".cyan
-          puts
+          puts "** #{pr.html_url}".cyan.bold
 
-          success = backport_pr(pr.number, pr.user.login)
+          success = backportable?(pr) && backport_pr(pr.number, pr.user.login)
           puts
 
           if success
             repo.git.log("-1")
             puts
           else
-            puts "A conflict occurred during backport. Stopping backports for #{github_repo}.".red
+            puts "A conflict was encountered during backport.".red
+            puts "Stopping backports for #{github_repo}.".red
             break
           end
         end
@@ -94,6 +94,10 @@ module ManageIQ
 
           false
         end
+      end
+
+      def backportable?(pr)
+        pr.labels.none? { |l| l.name == "#{branch}/conflict" }
       end
 
       def merge_commit_sha(pr_number)


### PR DESCRIPTION
Before this commit, the backport_prs script will skip a repo if a
conflict exists anywhere in the repo, even if there are PRs that can be
backported prior to the conflicting PR. This commit changes that flow to
allow all of those PRs to be backported and then stopping at the
conflict PR explicitly.

@agrare Please review.