### PR TITLE
Try to backport anyway, regardless of conflict label

### DIFF
--- a/lib/manageiq/release/backport_prs.rb
+++ b/lib/manageiq/release/backport_prs.rb
@@ -43,18 +43,16 @@ module ManageIQ
             handle_already_on_branch(pr)
 
             puts "The commit already exists on the branch. Skipping.".yellow
-          else
-            success = backport_pr(pr)
+          elsif backport_pr(pr)
             puts
-
-            if success
-              repo.git.log("-1")
-              puts
-            else
-              puts "A conflict was encountered during backport.".red
-              puts "Stopping backports for #{github_repo}.".red
-              break
-            end
+            repo.git.log("-1")
+            puts
+          else
+            puts
+            puts "A conflict was encountered during backport.".red
+            puts "Stopping backports for #{github_repo}.".red
+            break
+          end
           end
         end
         puts

--- a/lib/manageiq/release/backport_prs.rb
+++ b/lib/manageiq/release/backport_prs.rb
@@ -39,15 +39,12 @@ module ManageIQ
           puts
           puts "** #{pr.html_url}".cyan.bold
 
-          pr_number = pr.number
-          pr_author = pr.user.login
-
-          if already_on_branch?(pr_number)
-            handle_already_on_branch(pr_number)
+          if already_on_branch?(pr)
+            handle_already_on_branch(pr)
 
             puts "The commit already exists on the branch. Skipping.".yellow
           else
-            success = backportable?(pr) && backport_pr(pr_number, pr_author)
+            success = backportable?(pr) && backport_pr(pr)
             puts
 
             if success
@@ -63,8 +60,8 @@ module ManageIQ
         puts
       end
 
-      def backport_pr(pr_number, pr_author)
-        success, failure_diff = cherry_pick(merge_commit_sha(pr_number))
+      def backport_pr(pr)
+        success, failure_diff = cherry_pick(merge_commit_sha(pr.number))
 
         if success
           message = <<~BODY
@@ -76,14 +73,14 @@ module ManageIQ
           BODY
 
           push_backport_commit
-          add_comment(pr_number, message)
-          remove_label(pr_number, "#{branch}/yes")
-          add_label(pr_number, "#{branch}/backported")
+          add_comment(pr.number, message)
+          remove_label(pr.number, "#{branch}/yes")
+          add_label(pr.number, "#{branch}/backported")
 
           true
         else
           message = <<~BODY
-            @#{pr_author} A conflict occurred during the backport of this pull request to `#{branch}`.
+            @#{pr.user.login} A conflict occurred during the backport of this pull request to `#{branch}`.
 
             If this pull request is based on another pull request that has not been \
             marked for backport, add the appropriate labels to the other pull request. \
@@ -98,26 +95,26 @@ module ManageIQ
           BODY
           message = "#{message[0, 65_530]}\n```\n" if message.size > 65_535
 
-          add_comment(pr_number, message)
-          add_label(pr_number, "#{branch}/conflict")
+          add_comment(pr.number, message)
+          add_label(pr.number, "#{branch}/conflict")
 
           false
         end
       end
 
-      def handle_already_on_branch(pr_number)
+      def handle_already_on_branch(pr)
         message = <<~BODY
           Skipping backport to `#{branch}`, because it is already in the branch.
         BODY
 
-        add_comment(pr_number, message)
-        remove_label(pr_number, "#{branch}/yes")
+        add_comment(pr.number, message)
+        remove_label(pr.number, "#{branch}/yes")
 
         true
       end
 
-      def already_on_branch?(pr_number)
-        repo.git.capturing.branch("--contains", merge_commit_sha(pr_number), branch).present?
+      def already_on_branch?(pr)
+        repo.git.capturing.branch("--contains", merge_commit_sha(pr.number), branch).present?
       end
 
       def backportable?(pr)


### PR DESCRIPTION
Prior to this commit, the code would check for the conflict label and
just stop processing. Instead, this commit changes it so that it will
try and backport anyway. This helps in cases where someone marks a
different PR for backport, which frees up the conflict PR, so they don't
need to actually remove the conflict. Checking for a conflict is not
expensive, and if we find we are still in conflict, then we can check if
the issue is already labeled or not.

This PR also simplifies the code to pass around the pr object instead of decomposing it.

@chessbyte Please review.  The second commit is the main change.