### PR TITLE
Change travis status dates to relative times and sort properly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ plugin 'bundler-inject'
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
 gem "activesupport",        :require => false
+gem "actionview",           :require => false
 gem "aws-sdk-s3",           :require => false
 gem "builder",              :require => false
 gem "config",               :require => false

--- a/bin/show_travis_status.rb
+++ b/bin/show_travis_status.rb
@@ -5,6 +5,7 @@ $LOAD_PATH << File.expand_path("../lib", __dir__)
 require 'bundler/setup'
 require 'manageiq/release'
 require 'more_core_extensions/core_ext/array/tableize'
+require 'action_view' # For ActionView::Helpers::DateHelper
 require 'travis'
 require 'travis/pro/auto_login'
 require 'optimist'
@@ -17,6 +18,8 @@ end
 opts[:repo_set] = opts[:ref].split("-").first unless opts[:repo] || opts[:repo_set]
 
 ManageIQ::Release::StringFormatting.enable
+
+date_helper = Class.new { include ActionView::Helpers::DateHelper }.new
 
 travis_repos = ManageIQ::Release.repos_for(opts).collect do |repo|
   next if repo.options.has_real_releases
@@ -41,9 +44,22 @@ travis_repos = ManageIQ::Release.repos_for(opts).collect do |repo|
       [last_build.state, 3]
     end
 
+  date_sort = last_build.finished_at
+  date      = "#{date_helper.time_ago_in_words(date_sort)} ago" if date_sort
+
   last_build_url = "https://travis-ci.com/github/#{last_build.repository.slug}/builds/#{last_build.id}"
-  {"Repo" => repo.name, "Status" => status, "Status Sort" => status_sort, "Date" => last_build.finished_at, "URL" => last_build_url}
+
+  {
+    "Repo"        => repo.name,
+    "Status"      => status,
+    "Status Sort" => status_sort,
+    "Date"        => date,
+    "Date Sort"   => date_sort,
+    "URL"         => last_build_url
+  }
 end.compact
 
-travis_repos.sort_by! { |v| [ v["Status Sort"], v["Date"] ] }
+# Reverse sort by date then stable sort by status
+travis_repos = travis_repos.sort_by { |v| v["Date Sort"].to_s }.reverse.sort_by.with_index { |v, n| [v["Status Sort"], n] }
+
 puts travis_repos.tableize(:columns => ["Repo", "Status", "Date", "URL"])


### PR DESCRIPTION
@agrare Please review.

It turns out the sorting by date was ascending which was wrong.  I noticed this immediately after adding relative times.

Before:
![Notification_Center](https://user-images.githubusercontent.com/52120/136258371-d5e40710-3bbe-4ef4-8865-2df6d4fbbc6c.png)

After:
![Notification_Center](https://user-images.githubusercontent.com/52120/136258482-74e2777e-2289-492b-8f64-ce87597ffd55.png)


