### PR TITLE
Don't warn on mirror to backup if backup is not defined

### DIFF
--- a/lib/manageiq/release/git_mirror.rb
+++ b/lib/manageiq/release/git_mirror.rb
@@ -41,12 +41,12 @@ module ManageIQ
       def mirror_upstream_repo(repo)
         mirror_remote_refs("upstream", "downstream")
         mirror_branches(repo, "upstream", "downstream")
-        mirror_remote_refs("downstream", "backup")
+        mirror_remote_refs("downstream", "backup") if Settings.git_mirror.remotes.backup
       end
 
       def mirror_downstream_repo(repo)
         mirror_branches(repo, "downstream", "downstream")
-        mirror_remote_refs("downstream", "backup")
+        mirror_remote_refs("downstream", "backup") if Settings.git_mirror.remotes.backup
       end
 
       def dry_run?


### PR DESCRIPTION
@bdunne Please review.

This will quiet down a lot of the visual warnings and noise when you don't have a backup defined.  Right now you see a lot of the following over and over, and it's not really telling me what I don't already know because I intentionally don't have a backup defined.

```
! Skipping sync of master to backup/foo since backup remote does not exist

==== Mirroring downstream to backup ====
! Skipping mirror of downstream to backup since backup does not exist
```
