### PR TITLE
Remove v2v and graphql plugins

### DIFF
--- a/config/labels.yml
+++ b/config/labels.yml
@@ -66,9 +66,6 @@ ux: &ux
   ux/review: "cc317c"
   ux/approved: "0e8a16"
 
-v2v: &v2v
-  v2v: "5319e7"
-
 #
 # Release label definitions
 #
@@ -169,7 +166,6 @@ repos:
     <<: *repo_introduced_in_hammer_or_prior
     <<: *provider_types
     <<: *release
-    <<: *v2v
   ManageIQ/manageiq-api:
     <<: *common
     <<: *repo_introduced_in_hammer_or_prior
@@ -188,7 +184,6 @@ repos:
     <<: *common
     <<: *repo_introduced_in_hammer_or_prior
     <<: *release
-    <<: *v2v
   ManageIQ/manageiq-consumption:
     <<: *common
     <<: *repo_introduced_in_hammer_or_prior
@@ -198,7 +193,6 @@ repos:
     <<: *repo_introduced_in_hammer_or_prior
     <<: *provider_types
     <<: *release
-    <<: *v2v
   ManageIQ/manageiq-decorators:
     <<: *common
     <<: *repo_introduced_in_ivanchuk
@@ -207,10 +201,6 @@ repos:
     <<: *repo_introduced_in_hammer_or_prior
     <<: *release
   ManageIQ/manageiq-gems-pending:
-    <<: *common
-    <<: *repo_introduced_in_hammer_or_prior
-    <<: *release
-  ManageIQ/manageiq-graphql:
     <<: *common
     <<: *repo_introduced_in_hammer_or_prior
     <<: *release
@@ -342,24 +332,16 @@ repos:
     <<: *repo_introduced_in_hammer_or_prior
     <<: *provider_types
     <<: *release
-    <<: *v2v
   ManageIQ/manageiq-ui-classic:
     <<: *common
     <<: *repo_introduced_in_hammer_or_prior
     <<: *release
     <<: *ux
-    <<: *v2v
   ManageIQ/manageiq-ui-service:
     <<: *common
     <<: *repo_introduced_in_hammer_or_prior
     <<: *release
     <<: *ux
-  ManageIQ/manageiq-v2v:
-    <<: *common
-    <<: *repo_introduced_in_hammer_or_prior
-    <<: *release
-    <<: *ux
-    <<: *v2v
   #
   # Released gems and packages
   #

--- a/config/repos.sets.yml
+++ b/config/repos.sets.yml
@@ -7,11 +7,9 @@ core: &core
   manageiq-content:
   manageiq-decorators:
   manageiq-gems-pending:
-  manageiq-graphql:
   manageiq-schema:
   manageiq-ui-classic:
   manageiq-ui-service:
-  manageiq-v2v:
 providers: &providers
   manageiq-providers-amazon:
   manageiq-providers-ansible_tower:

--- a/config/repos.yml
+++ b/config/repos.yml
@@ -36,7 +36,6 @@ master:
     has_rake_release_new_branch: true
     has_rake_release_new_branch_master: true
   manageiq-gems-pending:
-  manageiq-graphql:
   manageiq-pods:
     has_rake_release_new_branch: true
     has_rake_release_new_branch_master: true
@@ -73,7 +72,6 @@ master:
     has_real_releases: true
   manageiq-ui-classic:
   manageiq-ui-service:
-  manageiq-v2v:
   ui-components:
     skip_tag: true
 morphy:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,7 +15,7 @@
     manageiq-decorators:
     manageiq-documentation:
     manageiq-gems-pending:
-    manageiq-graphql:
+    manageiq-graphql: # Keep for mirroring until we don't need old versions
     manageiq-pods:
     manageiq-providers-amazon:
     manageiq-providers-ansible_tower:
@@ -44,7 +44,7 @@
     manageiq-schema:
     manageiq-ui-classic:
     manageiq-ui-service:
-    manageiq-v2v:
+    manageiq-v2v: # Keep for mirroring until we don't need old versions
     manageiq:
   :working_directory: mirrors
 :manageiq_rubygems:


### PR DESCRIPTION
v2v dropped in ManageIQ/manageiq#21379
graphql dropped in ManageIQ/manageiq#21380

@jrafanie Please review.