### PR TITLE
Add each_repo script

### DIFF
--- a/bin/each_repo.rb
+++ b/bin/each_repo.rb
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path("../lib", __dir__)
+
+require 'bundler/setup'
+require 'manageiq/release'
+require 'optimist'
+
+opts = Optimist.options do
+  opt :command, "A command to run in each repo", :type => :string, :required => true
+  opt :ref, "Ref to checkout before running the command", :type => :string, :default => "master"
+
+  ManageIQ::Release.common_options(self, :except => :dry_run)
+end
+
+ManageIQ::Release.each_repo(**opts) do |r|
+  r.fetch
+  r.checkout(opts[:ref])
+  r.chdir do
+    puts "+ #{opts[:command]}"
+    system(opts[:command])
+  end
+end


### PR DESCRIPTION
I can't believe I've gone this long without this script, cause this is easily one of the most useful things I've written for this repo.  🤦

Basically, it's a script that runs the given command in each repo on the specific branch.  That's it.  If I need to quick run a scan of some sort in each repo, I just write it.

Example usage I just did to find all instances of badly named spec files:

```sh
bin/each_repo.rb -c 'find spec -type f -not -name *_spec.rb | grep -v "spec/\(dummy\|factories\|fixtures\|javascripts\|manageiq\|shared\|support\|tools\|vcr_cassettes\)/" | grep -v "spec/\(spec\|coverage\|rails\)_helper.rb" | grep -v "/\(data\|shared_examples\)/"'
```

@chessbyte Please review.  cc @bdunne @agrare @jrafanie 
