### PR TITLE
Stop using the deprecated preserve in favor of merges

### DIFF
--- a/lib/manageiq/release/git_mirror.rb
+++ b/lib/manageiq/release/git_mirror.rb
@@ -161,7 +161,7 @@ module ManageIQ
 
         success =
           system("git checkout -B #{dest_name} #{start_point}") &&
-          system("git pull --rebase=preserve #{source_remote} #{source_name}") &&
+          system("git pull --rebase=merges #{source_remote} #{source_name}") &&
           system("git push -f #{dest_remote} #{dest_name}")
 
         if backup_remote_defined?


### PR DESCRIPTION
preserve is removed in git 2.35.1, so this will allow us to use newer
gits

@bdunne @chessbyte Please review.