### PR TITLE
Fix issue with the check for repo and labels config

### DIFF
--- a/bin/new_plugin_repo.rb
+++ b/bin/new_plugin_repo.rb
@@ -10,9 +10,12 @@ opts = Optimist.options do
   ManageIQ::Release.common_options(self, :except => :repo_set)
 end
 
-repo = ManageIQ::Release.repo_for(opts[:repo].first)
-labels = ManageIQ::Release::Labels[repo.github_repo]
-unless repo && labels
+repo_name = opts[:repo].first
+repo = ManageIQ::Release.repo_for(repo_name)
+
+has_repo = ManageIQ::Release::RepoSet.config["master"].include?(repo_name)
+has_labels = ManageIQ::Release::Labels.config["repos"][repo.github_repo]
+unless has_repo && has_labels
   STDERR.puts "ERROR: First update config/repos.yml and config/labels.yml with the new repo"
   exit 1
 end
@@ -36,6 +39,8 @@ ManageIQ::Release::PullRequestBlasterOuter.new(repo, opts.merge(
 
 puts
 puts "******* MANUAL THINGS *******"
+puts "- Add repo to repos.sets.yml if this is a new core or provider plugin"
+puts "- Add repo to mirror settings"
 puts "- https://codeclimate.com/github/#{repo.github_repo} => Repo Settings => GitHub => Pull Request Status Updates => Install"
 puts "- https://gitter.im/ManageIQ#createroom and create a new room linked to the repository"
 puts "- Add repo to the bot"

--- a/lib/manageiq/release/labels.rb
+++ b/lib/manageiq/release/labels.rb
@@ -21,7 +21,6 @@ module ManageIQ
       def self.config
         @config ||= ManageIQ::Release.load_config_file("labels")
       end
-      private_class_method :config
     end
   end
 end

--- a/lib/manageiq/release/repo_set.rb
+++ b/lib/manageiq/release/repo_set.rb
@@ -18,7 +18,6 @@ module ManageIQ
       def self.config
         @config ||= ManageIQ::Release.load_config_file("repos")
       end
-      private_class_method :config
     end
   end
 end


### PR DESCRIPTION
@agrare Please review.

2 prior changes to make getting Repo and Labels objects easier caused this check to no longer function properly.  This change now ensures those values are configured properly before starting.