### PR TITLE
YAML.load_file converts on: to true:

### DIFF
--- a/scripts/pull_request_blaster_outer/change_ci_ruby_versions.rb
+++ b/scripts/pull_request_blaster_outer/change_ci_ruby_versions.rb
@@ -18,8 +18,10 @@ sorted_versions = versions.sort {|x, y| Gem::Version.new(x) <=> Gem::Version.new
 
 changed = false
 
+content = File.read(ci).gsub(/^\s*on:/, "\"on\":")
+
 require "yaml"
-yaml = YAML.load_file(ci)
+yaml = YAML.load(content)
 
 require "more_core_extensions/core_ext/hash"
 if yaml.fetch_path("jobs", "ci", "strategy", "matrix", "ruby-version") && yaml.fetch_path("jobs", "ci", "strategy", "matrix", "ruby-version") != sorted_versions


### PR DESCRIPTION
Quote the "on" keys to prevent it from turning to "true"

Followup to: https://github.com/ManageIQ/manageiq-release/pull/259

Before:
```diff
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,19 +1,17 @@
+---
 name: CI
-
-on:
+true:
   push:
   pull_request:
   workflow_dispatch:
   schedule:
-  - cron: '0 0 * * *'
+  - cron: 0 0 * * *
   ci:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby-version:
-        - '2.6'
         - '2.7'
     services:
       postgres:
           POSTGRESQL_USER: root
           POSTGRESQL_PASSWORD: smartvm
           POSTGRESQL_DATABASE: vmdb_test
-        options: --health-cmd pg_isready --health-interval 2s --health-timeout 5s --health-retries 5
+        options: "--health-cmd pg_isready --health-interval 2s --health-timeout 5s
+          --health-retries 5"
         ports:
         - 5432:5432
       memcached:
@@ -32,7 +31,7 @@ jobs:
       PGHOST: localhost
       PGPASSWORD: smartvm
-      CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+      CC_TEST_REPORTER_ID: "${{ secrets.CC_TEST_REPORTER_ID }}"
```

After:
```diff
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,19 +1,17 @@
+---
 name: CI
-
-on:
+'on':
   push:
   pull_request:
   workflow_dispatch:
   schedule:
-  - cron: '0 0 * * *'
-
+  - cron: 0 0 * * *
 jobs:
   ci:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby-version:
-        - '2.6'
         - '2.7'
     services:
       postgres:
@@ -22,7 +20,8 @@ jobs:
           POSTGRESQL_USER: root
           POSTGRESQL_PASSWORD: smartvm
           POSTGRESQL_DATABASE: vmdb_test
-        options: --health-cmd pg_isready --health-interval 2s --health-timeout 5s --health-retries 5
+        options: "--health-cmd pg_isready --health-interval 2s --health-timeout 5s
+          --health-retries 5"
         ports:
         - 5432:5432
       memcached:
@@ -32,7 +31,7 @@ jobs:
     env:
       PGHOST: localhost
       PGPASSWORD: smartvm
-      CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+      CC_TEST_REPORTER_ID: "${{ secrets.CC_TEST_REPORTER_ID }}"
     steps:
     - uses: actions/checkout@v2
     - name: Set up system
@@ -40,7 +39,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby-version }}
+        ruby-version: "${{ matrix.ruby-version }}"
         bundler-cache: true
       timeout-minutes: 30
     - name: Prepare tests
@@ -48,6 +47,6 @@ jobs:
     - name: Run tests
       run: bundle exec rake
     - name: Report code coverage
-      if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '2.7' }}
+      if: "${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '2.7' }}"
       continue-on-error: true
       uses: paambaati/codeclimate-action@v3.0.0
```