### PR TITLE
Use explicit keyword arguments where they're expected

### DIFF
--- a/bin/pull_request_blaster_outer.rb
+++ b/bin/pull_request_blaster_outer.rb
@@ -17,8 +17,8 @@ opts = Optimist.options do
 end
 
 results = {}
-ManageIQ::Release.each_repo(opts) do |repo|
-  results[repo.github_repo] = ManageIQ::Release::PullRequestBlasterOuter.new(repo, opts).blast
+ManageIQ::Release.each_repo(**opts) do |repo|
+  results[repo.github_repo] = ManageIQ::Release::PullRequestBlasterOuter.new(repo, **opts).blast
 end
 
 require 'pp'


### PR DESCRIPTION
In ruby 3, you must use keyword arguments when they're required.  Hashes will no longer be treated as kwargs in ruby 3.

This has been tested with ruby 2.7 and 3.0.