### PR TITLE
Fix YAML syntax for multiple merge keys

### DIFF
--- a/config/labels.yml
+++ b/config/labels.yml
@@ -112,16 +112,19 @@ repo_introduced_in_petrosian: &repo_introduced_in_petrosian
   <<: *release_petrosian
 
 repo_introduced_in_oparin: &repo_introduced_in_oparin
-  <<: *release_oparin
-  <<: *repo_introduced_in_petrosian
+  <<:
+  - *release_oparin
+  - *repo_introduced_in_petrosian
 
 repo_introduced_in_najdorf: &repo_introduced_in_najdorf
-  <<: *release_najdorf
-  <<: *repo_introduced_in_oparin
+  <<:
+  - *release_najdorf
+  - *repo_introduced_in_oparin
 
 repo_introduced_in_morphy: &repo_introduced_in_morphy_or_prior
-  <<: *release_morphy
-  <<: *repo_introduced_in_najdorf
+  <<:
+  - *release_morphy
+  - *repo_introduced_in_najdorf
 
 #
 # Label Assignments
@@ -138,261 +141,318 @@ orgs:
 
 repos:
   ManageIQ/amazon_ssa_support:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *release
   ManageIQ/container-amazon-smartstate:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *release
   ManageIQ/manageiq:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_types
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_types
+    - *release
   ManageIQ/manageiq-api:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_types
-    <<: *release
-    <<: *semver
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_types
+    - *release
+    - *semver
   ManageIQ/manageiq-appliance:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *release
   ManageIQ/manageiq-appliance-build:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *release
   ManageIQ/manageiq-automation_engine:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *release
   ManageIQ/manageiq-consumption:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *release
   ManageIQ/manageiq-content:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_types
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_types
+    - *release
   ManageIQ/manageiq-decorators:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *release
   ManageIQ/manageiq-documentation:
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *release
+    <<:
+    - *repo_introduced_in_morphy_or_prior
+    - *release
   ManageIQ/manageiq-gems-pending:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *release
   ManageIQ/manageiq-pods:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *release
   ManageIQ/manageiq-providers-amazon:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-ansible_tower:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-autosde:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-awx:
-    <<: *common
-    <<: *repo_introduced_in_oparin
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_oparin
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-azure:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-azure_stack:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-cisco_intersight:
-    <<: *common
-    <<: *repo_introduced_in_najdorf
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_najdorf
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-foreman:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-google:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-ibm_cic:
-    <<: *common
-    <<: *repo_introduced_in_najdorf
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_najdorf
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-ibm_cloud:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-ibm_power_hmc:
-    <<: *common
-    <<: *repo_introduced_in_najdorf
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_najdorf
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-ibm_power_vc:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-ibm_terraform:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-kubernetes:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-kubevirt:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-lenovo:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-nsxt:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-nuage:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-openshift:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-openstack:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-oracle_cloud:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-ovirt:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-red_hat_virtualization:
-    <<: *common
-    <<: *repo_introduced_in_oparin
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_oparin
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-redfish:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-scvmm:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-vmware:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-providers-workflows:
-    <<: *common
-    <<: *repo_introduced_in_petrosian
-    <<: *provider_plugin
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_petrosian
+    - *provider_plugin
+    - *release
   ManageIQ/manageiq-rpm_build:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *release
   ManageIQ/manageiq-schema:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *provider_types
-    <<: *release
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *provider_types
+    - *release
   ManageIQ/manageiq-ui-classic:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *release
-    <<: *ux
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *release
+    - *ux
   ManageIQ/manageiq-ui-service:
-    <<: *common
-    <<: *repo_introduced_in_morphy_or_prior
-    <<: *release
-    <<: *ux
+    <<:
+    - *common
+    - *repo_introduced_in_morphy_or_prior
+    - *release
+    - *ux
   #
   # Released gems and packages
   #
   ansible/ansible_tower_client_ruby:
-    <<: *common
-    <<: *semver
+    <<:
+    - *common
+    - *semver
   ManageIQ/dbus_api_service:
-    <<: *common
-    <<: *release
-    <<: *semver
+    <<:
+    - *common
+    - *release
+    - *semver
   ManageIQ/floe:
-    <<: *common
-    <<: *semver
+    <<:
+    - *common
+    - *semver
   ManageIQ/httpd_configmap_generator:
-    <<: *common
-    <<: *release
-    <<: *semver
+    <<:
+    - *common
+    - *release
+    - *semver
   ManageIQ/inventory_refresh:
-    <<: *common
-    <<: *semver
+    <<:
+    - *common
+    - *semver
   ManageIQ/log_decorator:
-    <<: *common
-    <<: *semver
+    <<:
+    - *common
+    - *semver
   ManageIQ/manageiq-appliance_console:
-    <<: *common
-    <<: *release
-    <<: *semver
+    <<:
+    - *common
+    - *release
+    - *semver
   ManageIQ/manageiq-messaging:
-    <<: *common
-    <<: *semver
+    <<:
+    - *common
+    - *semver
   ManageIQ/manageiq-smartstate:
-    <<: *common
-    <<: *release
-    <<: *semver
+    <<:
+    - *common
+    - *release
+    - *semver
   ManageIQ/multi_repo:
-    <<: *common
-    <<: *semver
+    <<:
+    - *common
+    - *semver
   ManageIQ/rbvmomi2:
-    <<: *common
-    <<: *release
-    <<: *semver
+    <<:
+    - *common
+    - *release
+    - *semver
   ManageIQ/ui-components:
-    <<: *common
-    <<: *semver
-    <<: *ux
+    <<:
+    - *common
+    - *semver
+    - *ux

--- a/config/repos.sets.yml
+++ b/config/repos.sets.yml
@@ -39,5 +39,6 @@ providers: &providers
   ManageIQ/manageiq-providers-vmware:
   ManageIQ/manageiq-providers-workflows:
 all:
-  <<: *core
-  <<: *providers
+  <<:
+  - *core
+  - *providers


### PR DESCRIPTION
Multiple instances of `<<:` for merge keys was removed in the YAML 1.2 spec, but many parsers still accept it.  However, vscode only supports the newer YAML spec, and so these lines show up as errors.  Instead, we can use an array of references within the merge key.

See also https://stackoverflow.com/a/64228697/2355944

@agrare Please review.