### PR TITLE
Add PR blaster script for updating yarn versions

### DIFF
--- a/scripts/pull_request_blaster_outer/update_yarn_versions.rb
+++ b/scripts/pull_request_blaster_outer/update_yarn_versions.rb
@@ -1,0 +1,16 @@
+#! /usr/bin/env ruby
+
+ENV["YARN_VERSION"] ||= "berry"
+
+def system!(cmd)
+  puts "** #{cmd}"
+  system(cmd).tap do
+    exit $?.exitstatus unless $?.success?
+  end
+end
+
+if File.exist?(".yarnrc.yml")
+  system!("yarn set version #{ENV.fetch("YARN_VERSION")}")
+  FileUtils.rm_f("yarn.lock") if ENV["RM_YARN_LOCK"]
+  system!("yarn install")
+end


### PR DESCRIPTION
@bdunne Please review.  This script was used to bump the yarn versions recently.  I will probably need to do this relatively frequently to ensure we are on a later yarn 4 rc until yarn 4 is stable.