### PR TITLE
Fixes on release_merged_branch

### DIFF
--- a/bin/release_merged_branch
+++ b/bin/release_merged_branch
@@ -51,7 +51,8 @@ class ReleaseMergedBranch
 
     repo.chdir do
       begin
-        repo.git.client.merge("--no-ff", "--no-edit", "origin/#{source_branch}")
+        FileUtils.rm_rf(".git/rr-cache") # Clear the rerere cache
+        repo.git.client.merge("--no-ff", "--no-edit", "-Xtheirs", "origin/#{source_branch}")
       rescue MiniGit::GitError
         $stderr.puts("ERROR: An error has occurred during git merge and may require manual conflict resolution.".light_red)
         $stderr.puts("  Repo: #{repo.path}")


### PR DESCRIPTION
- If git rerere is enabled locally it can cause problems between subsequent runs of the release_merged_branch script, so we now remove the rerere cache.
- Adding -Xtheirs allows the master version of a conflict to win out. On the initial merge however we will also need to revert the changes on master that bump the version, however this commit does not include that change for now.

@bdunne Please review.