### PR TITLE
Gem::Indexer has been extracted from rubygems

### DIFF
--- a/bin/miq_gem_push
+++ b/bin/miq_gem_push
@@ -7,6 +7,7 @@ gemfile do
   gem "aws-sdk-s3"
   gem "config"
   gem "more_core_extensions"
+  gem "rubygems-generate_index"
 end
 
 require 'fileutils'


### PR DESCRIPTION
Error:

```
Created tempdir at /tmp/d20250113-228396-l2zv7q
Fetching index pack...
Unpacking index pack...
Updating rubygems index
/home/bdunne/.rubies/ruby-3.3.6/lib/ruby/3.3.0/bundled_gems.rb:69:in `require': cannot load such file -- rubygems/indexer (LoadError)
	from /home/bdunne/.rubies/ruby-3.3.6/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
	from bin/miq_gem_push:91:in `block in <main>'
	from /home/bdunne/.rubies/ruby-3.3.6/lib/ruby/3.3.0/tmpdir.rb:99:in `mktmpdir'
	from bin/miq_gem_push:77:in `<main>'
```