### PR TITLE
Add kubevirt-sdk-ruby repo

### DIFF
--- a/bin/new_repo
+++ b/bin/new_repo
@@ -38,7 +38,7 @@ code_climate.create_repo_secret
 
 puts
 puts "******* MANUAL THINGS *******"
-puts "- https://github.com/ManageIQ/#{repo.name}/settings/access should have the following teams"
+puts "- https://github.com/#{repo.name}/settings/access should have the following teams"
 puts "  - bots (Write permission)"
 puts "  - core-admins (Admin permission)"
 if opts[:plugin]

--- a/config/labels.yml
+++ b/config/labels.yml
@@ -467,6 +467,10 @@ repos:
     <<:
     - *common
     - *semver
+  ManageIQ/kubevirt-sdk-ruby:
+    <<:
+    - *common
+    - *semver
   ManageIQ/log_decorator:
     <<:
     - *common

--- a/config/repos.other.yml
+++ b/config/repos.other.yml
@@ -12,6 +12,7 @@ gems:
   ManageIQ/foreman_api_client:
   ManageIQ/httpd_configmap_generator:
   ManageIQ/inventory_refresh:
+  ManageIQ/kubevirt-sdk-ruby:
   ManageIQ/linux_admin:
   ManageIQ/linux_block_device:
   ManageIQ/log_decorator:


### PR DESCRIPTION
This also fixes a bug in the new_repo script where the URL had ManageIQ listed twice, since ManageIQ is already in the repo name.

@agrare Please review.