### PR TITLE
Add revert of master changes after merging back into release branch

### DIFF
--- a/bin/release_merged_branch
+++ b/bin/release_merged_branch
@@ -50,12 +50,27 @@ class ReleaseMergedBranch
     repo.git.hard_checkout(branch)
 
     repo.chdir do
+      # Determine the commit SHA that makes changes on master for the next release, so we can undo that.
+      # This should be the first commit on master after the merge base.
+      revert_sha, comment = repo.git.client.capturing.log("--ancestry-path", {:format => "\%H\t\%s"}, "#{repo.git.client.capturing.merge_base(branch, source_branch).chomp}..#{source_branch}").chomp.split("\t")
+      revert_sha = nil unless comment == "Changes after new branch #{branch}"
+
       begin
         FileUtils.rm_rf(".git/rr-cache") # Clear the rerere cache
         repo.git.client.merge("--no-ff", "--no-edit", "-Xtheirs", "origin/#{source_branch}")
       rescue MiniGit::GitError
         $stderr.puts("ERROR: An error has occurred during git merge and may require manual conflict resolution.".light_red)
         $stderr.puts("  Repo: #{repo.path}")
+        $stderr.puts("  Fix the error and press Enter to continue...")
+        $stdin.gets
+      end
+
+      begin
+        repo.git.client.revert("--no-edit", revert_sha) if revert_sha
+      rescue MiniGit::GitError
+        $stderr.puts("ERROR: An error has occurred during git revert and may require manual conflict resolution.".light_red)
+        $stderr.puts("  Repo: #{repo.path}")
+        $stderr.puts("  Commit: #{revert_sha}")
         $stderr.puts("  Fix the error and press Enter to continue...")
         $stdin.gets
       end
@@ -71,7 +86,7 @@ class ReleaseMergedBranch
   end
 
   def review
-    branch_diff = pretty_log(branch, 2)
+    branch_diff = pretty_log(branch, 3)
 
     [
       MultiRepo::CLI.header("#{branch} changes", "-"),
@@ -86,6 +101,7 @@ class ReleaseMergedBranch
   end
 end
 
+require "stringio"
 review = StringIO.new
 post_review = StringIO.new
 


### PR DESCRIPTION
On master, immediately after branching a commit is made for the next release to update things like the release name, rpm repositories, etc. When master is merged back into a release branch those changes should _not_ come over, so we need to revert that particular commit.

@bdunne This was used for the recent merge of master into spassky.  See https://github.com/ManageIQ/manageiq-rpm_build/commit/efc2820f3232dcc1c7e541b04812ca463cc11add as an example revert that was made after the merge back.
