### PR TITLE
[release_branch] Drop buildstats reference

### DIFF
--- a/bin/release_branch
+++ b/bin/release_branch
@@ -115,7 +115,6 @@ class ReleaseBranch
       contents.gsub!(/(github\.com.+?branch=)#{source_branch}\b/, "\\1#{branch}")
       contents.gsub!(/(github\.com.+?\.svg)\)/, "\\1?branch=#{branch})")
       contents.gsub!(/(coveralls\.io.+?branch=)#{source_branch}\b/, "\\1#{branch}")
-      contents.gsub!(/Build history for (?:master|#{source_branch}) branch/, "Build history for #{branch} branch")
       contents
     end
 


### PR DESCRIPTION
Follow up to https://github.com/ManageIQ/manageiq/pull/23466 and the related PRs