### PR TITLE
Add ui repo set for quick UI cross-repo testing

### DIFF
--- a/config/repos.sets.yml
+++ b/config/repos.sets.yml
@@ -46,3 +46,16 @@ all:
   <<:
   - *core
   - *providers
+ui:
+  ManageIQ/manageiq-ui-classic:
+  ManageIQ/manageiq-ui-service:
+  ManageIQ/ui-components:
+  # Providers that bring UI
+  ManageIQ/manageiq-providers-cisco_intersight:
+  ManageIQ/manageiq-providers-ibm_cloud:
+  ManageIQ/manageiq-providers-ibm_power_vc:
+  ManageIQ/manageiq-providers-lenovo:
+  ManageIQ/manageiq-providers-nsxt:
+  ManageIQ/manageiq-providers-redfish:
+  # Related enough to UI that cross-repo typically needs it
+  ManageIQ/manageiq-api:


### PR DESCRIPTION
@agrare Please review. Idea is that in a UI PR I can just quick cross-repo-test all the UI-related repos (including those plugins that bring UI).

cc @ManageIQ/core-ui 